### PR TITLE
Treat EOF at prompt as empty

### DIFF
--- a/googler
+++ b/googler
@@ -455,10 +455,13 @@ while True:
         results = fetch_results()
 
     oldstart = start
-    if sys.version_info > (3,):
-        nav = input("Enter 'n', 'p', 'g keywords', or result number to continue: ")
-    else:
-        nav = raw_input("Enter 'n', 'p', 'g keywords' or result number to continue: ")
+    try:
+        if sys.version_info > (3,):
+            nav = input("Enter 'n', 'p', 'g keywords', or result number to continue: ")
+        else:
+            nav = raw_input("Enter 'n', 'p', 'g keywords' or result number to continue: ")
+    except EOFError:
+        nav = ""
 
     if nav == "n":
         if num is not None:


### PR DESCRIPTION
Currently, ^D at googler's prompt result in an uncaught `EOFError`, but it doesn't need to be because ^D is a common way to exit shells. This commit makes EOF treated the same as empty input, i.e., exit.