### PR TITLE
README.md: Add Homebrew to the list of installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you do not want to install, `googler` is standalone:
 <pre>$ chmod +x googler
 $ ./googler ...</pre>
 
-3. `googler` is also available on <a href="https://aur.archlinux.org/packages/googler/">AUR</a> and <a href="http://fossies.org/linux/googler">Fossies</a>.
+3. `googler` is also available on <a href="https://aur.archlinux.org/packages/googler/">AUR</a>, <a href="http://fossies.org/linux/googler">Fossies</a> and <a href="http://braumeister.org/formula/googler">Homebrew</a> (`brew install googler`).
 
 # Usage
 


### PR DESCRIPTION
Homebrew doesn't have an official online package index, or in other words, https://github.com/Homebrew/homebrew/blob/master/Library/Formula/ is the official index:

```
> brew info googler
googler: stable 2.1 (bottled)
Google Search and News from the command-line
https://github.com/jarun/googler
/usr/local/Cellar/googler/2.1 (6 files, 68.6K) *
  Built from source
From: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/googler.rb
```

I'm linking to http://braumeister.org, the semi-official online package index (semi-official as in independently maintained but linked from official README), because it is more user-friendly to non-Homebrew-developers.

Not sure if you'll be satisfied with this format or not.