### PR TITLE
Log full HTML response to a tmpfile when debug is on

### DIFF
--- a/googler
+++ b/googler
@@ -27,6 +27,7 @@ import webbrowser
 import gzip
 from getopt import getopt, GetoptError
 import readline
+import tempfile
 # Try to load Py3 modules, on error fall back to Py2 module names
 try:
     from io import BytesIO
@@ -428,11 +429,20 @@ def fetch_results():
 
     # Parse the HTML document and print the results.
     parser = GoogleParser()
- 
+
     if sys.version_info > (3,):
-        parser.feed(gzip.GzipFile(fileobj = BytesIO(resp.read())).read().decode('utf-8'))
+        resp_body = gzip.GzipFile(fileobj = BytesIO(resp.read())).read().decode('utf-8')
     else:
-        parser.feed(gzip.GzipFile(fileobj = StringIO.StringIO(resp.read())).read().decode('utf-8'))
+        resp_body = gzip.GzipFile(fileobj = StringIO.StringIO(resp.read())).read().decode('utf-8')
+
+    if debug:
+        fd, tmpfile = tempfile.mkstemp(prefix='googler-response-')
+        os.close(fd)
+        with open(tmpfile, 'wb') as fp:
+            fp.write(resp_body.encode('utf-8'))
+        print("[DEBUG] Response body written to '%s'." % tmpfile)
+
+    parser.feed(resp_body)
 
     results = parser.results
     for r in results:


### PR DESCRIPTION
The full HTML response body is the single most valuable reproducer when something goes wrong during the handling of that response.

This commit writes it to a tmpfile (usually under `$TMPDIR`, with the `googler-response-` prefix) and prints the path to console when debug (`-d`) is on:

    [DEBUG] Response body written to '/tmp/googler-response-oqY18e'.

so when asked a user could supply that log to facilitate debugging.