### PR TITLE
Use logging.debug for printing debug info

### DIFF
--- a/googler
+++ b/googler
@@ -28,6 +28,7 @@ import gzip
 from getopt import getopt, GetoptError
 import readline
 import tempfile
+import logging
 # Try to load Py3 modules, on error fall back to Py2 module names
 try:
     from io import BytesIO
@@ -334,6 +335,15 @@ except GetoptError as e:
     print("googler:", e)
     sys.exit(1)
 
+# Set up logging
+logger = logging.getLogger(__name__)
+shell_formatter = logging.Formatter(fmt='[%(levelname)s] %(message)s')
+shell_handler = logging.StreamHandler()
+shell_handler.setFormatter(shell_formatter)
+logger.addHandler(shell_handler)
+if debug:
+    logger.setLevel(logging.DEBUG)
+
 # Construct the query URL.
 url = "/search?ie=UTF-8&oe=UTF-8&"
 
@@ -351,15 +361,13 @@ if duration is not None:
 baseurl = url
 basestart = start
 
-if debug:
-    print("[DEBUG] Base URL [%s]" % url)
+logger.debug("Base URL [%s]", url)
 
 url += "q=" + quote_plus(keywords[0])
 for kw in keywords[1:]:
     url += "+" + quote_plus(kw)
 
-if debug:
-    print("[DEBUG] Search URL [%s : %s]" % (server, url))
+logger.debug("Search URL [%s : %s]", server, url)
 
 # Get the terminal window size.
 winsz = fcntl.ioctl(sys.stderr, termios.TIOCGWINSZ, "1234")
@@ -381,8 +389,7 @@ def fetch_results():
         conn.request("GET", url, None, {"Accept-encoding": "gzip"})
         resp = conn.getresponse()
     except Exception as e:
-        if debug:
-            print("[DEBUG] Exception: %s" % e)
+        logger.debug("Exception: %s", e)
         conn.close()
         conn = HTTPSConnection(server, timeout=45)
         conn.request("GET", url, None, {"Accept-encoding": "gzip"})
@@ -391,21 +398,18 @@ def fetch_results():
     if resp.status != 200:
         if resp.status in (301, 302,):
             url = urljoin(url, resp.getheader('location', ''))
-            if debug:
-                print("[DEBUG] Redirected URL [%s]" % url)
+            logger.debug("Redirected URL [%s]", url)
             if url.find("sorry/IndexRedirect?") >= 0:
                 print("ERROR: Connection blocked due to unusual activity.")
                 conn.close()
                 sys.exit(1)
             conn.close()
-            if debug:
-                print("[DEBUG] Next Server [%s]" % url[url.find("//") +
-                      2:url.find("/search")])
+            logger.debug("Next Server [%s]", url[url.find("//") + 2:
+                                                 url.find("/search")])
             conn = HTTPSConnection(url[url.find("//") + 2:url.find("/search")],
                                    timeout=45)
             url = url[url.find("/search"):]
-            if debug:
-                print("[DEBUG] Next GET [%s]\n" % url)
+            logger.debug("Next GET [%s]\n", url)
 
             try:
                 conn.request("GET", url, None, {"Accept-encoding": "gzip"})
@@ -440,7 +444,7 @@ def fetch_results():
         os.close(fd)
         with open(tmpfile, 'wb') as fp:
             fp.write(resp_body.encode('utf-8'))
-        print("[DEBUG] Response body written to '%s'." % tmpfile)
+        logger.debug("Response body written to '%s'.", tmpfile)
 
     parser.feed(resp_body)
 
@@ -493,8 +497,7 @@ while True:
             print("Empty search. Exiting.")
             break
         url = baseurl + "q=" + trimsearch
-        if debug:
-            print("New search URL [%s]" % url)
+        logger.debug("New search URL [%s]", url)
         nav = "g"
         start = basestart
         print("\n\x1B[91m\x1B[1m     *****     *****     *****     *****\
@@ -521,8 +524,7 @@ while True:
             print("Empty search. Exiting.")
             break
         url = baseurl + "q=" + trimsearch
-        if debug:
-            print("New search URL [%s]" % url)
+        logger.debug("New search URL [%s]", url)
         nav = "g"
         start = basestart
         print("\n\x1B[91m\x1B[1m     *****     *****     *****     *****\
@@ -535,7 +537,6 @@ while True:
         start = "0"
 
     url = url.replace("start=" + oldstart + "&", "start=" + start + "&", 1)
-    if debug:
-        print("[DEBUG] Next URL [%s]\n" % url)
+    logger.debug("Next URL [%s]\n", url)
 
 conn.close()

--- a/googler
+++ b/googler
@@ -112,10 +112,10 @@ class GoogleParser(HTMLParser.HTMLParser):
                 self.url = self.url[:marker]
 
             if self.url != "":
-                if (self.url.find("://", 0, 12) >= 0):
+                if self.url.find("://", 0, 12) >= 0:
                     index = len(self.results) + 1
                     self.results.append(Result(index, self.title,
-                                    unquote(self.url), self.text))
+                                               unquote(self.url), self.text))
                 else:
                     skipped += 1
 
@@ -321,7 +321,7 @@ try:
         elif opt[0] == "-t":
             # Option -t dN
             duration = opt[1]
-            if not opt[1][0] in ("h", "d", "w", "m", "y",):
+            if opt[1][0] not in ("h", "d", "w", "m", "y",):
                 usage()
                 sys.exit(1)
             if not opt[1][1].isdigit():
@@ -435,9 +435,9 @@ def fetch_results():
     parser = GoogleParser()
 
     if sys.version_info > (3,):
-        resp_body = gzip.GzipFile(fileobj = BytesIO(resp.read())).read().decode('utf-8')
+        resp_body = gzip.GzipFile(fileobj=BytesIO(resp.read())).read().decode('utf-8')
     else:
-        resp_body = gzip.GzipFile(fileobj = StringIO.StringIO(resp.read())).read().decode('utf-8')
+        resp_body = gzip.GzipFile(fileobj=StringIO.StringIO(resp.read())).read().decode('utf-8')
 
     if debug:
         fd, tmpfile = tempfile.mkstemp(prefix='googler-response-')


### PR DESCRIPTION
Printing debug info with

```python
if debug:
    print("[DEBUG] blah blah")
```

is both overly verbose and non-idiomatic. It's also not extensible, as in it's hard to change message format, filter message level, change logging destination, etc. Using `logging.debug` is much better.

This commit introduces little user-facing changes, except:

1. Debugging info is now printed to stderr instead of stdout (should be considered an improvement);
2. "`New search URL`" or "`Next URL`" used to not be preceded with "`[DEBUG]`" (not sure why); after this commit they are treated the same as everything else, which improves consistency.

I also took the liberty to add another commit to fix some obvious style issues caught by pylint (I only fixed the hopefully noncontroversial ones), mostly because I don't think they deserve another PR, but they are nevertheless good to see fixed.