### PR TITLE
Fix failure when sys.stderr is not a tty (mostly for non-interactive invocation)

### DIFF
--- a/googler
+++ b/googler
@@ -195,7 +195,7 @@ class Result:
                   "\x1B[0m\n\x1B[93m%s\x1B[39m" % url)
         else:
             print("", index, title, "\n%s" % url)
-        # Print the text with truncating.
+        # Hard wrap text if the number of columns is available.
         if columns > 0:
             col = 0
             for w in text.split():
@@ -362,11 +362,14 @@ if debug:
     print("[DEBUG] Search URL [%s : %s]" % (server, url))
 
 # Get the terminal window size.
-winsz = fcntl.ioctl(sys.stderr, termios.TIOCGWINSZ, "1234")
-columns = struct.unpack("HH", winsz)[1]
+try:
+    winsz = fcntl.ioctl(sys.stderr, termios.TIOCGWINSZ, "1234")
+    columns = struct.unpack("HH", winsz)[1]
 
-if columns <= 0:
-    columns = int(os.environ.get('COLUMNS', 0))
+    if columns <= 0:
+        columns = int(os.environ.get('COLUMNS', 0))
+except IOError:
+    columns = 0
 
 # Connect to Google and request the result page.
 conn = HTTPSConnection(server, timeout=45)


### PR DESCRIPTION
I became aware of this the hard way when I was writing a test case for the [Homebrew formula](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/googler.rb). I didn't report at that time because this related to how the project owner defines the project. Now that I've been honored as a collaborator, I think I might be able to influence the project a little bit more substantially. So here it goes.

---
Currently, `fcntl.ioctl` fails with `IOError` (`OSError` on Python 3.x, where `IOError` is an alias for `OSError`) when sys.stderr is not a terminal. A very easy way to test:

```python-traceback
> googler hello 2>>(tee /dev/null) </dev/null
Traceback (most recent call last):
  File "./googler", line 365, in <module>
    winsz = fcntl.ioctl(sys.stderr, termios.TIOCGWINSZ, "1234")
IOError: [Errno 25] Inappropriate ioctl for device
```

Although googler is mostly terminal oriented, we should not preclude noninteractive use (it is an entirely conceivable use case to query googler with a set of keywords and grep out all URLs in the output); and even for interactive use, `2>/dev/null` leading to an error isn't nice UX either, especially considering that googler prints to stdout for the most part. This failure also precludes any meaningful automated testing.

This commit removes the aforementioned limitation, and also fixes a related comment (hard wrap != truncate, the latter implies loss of information).

---

If this one is merged, then the discussion can be taken to the next level: CI. I believe we'll greatly benefit from using a free CI, say Travis, to do automated testing against multiple Python versions and all TLDs, as well as a set of randomized queries to shake out both coding oversight (say, wrote something that's incompatible with Python 3.2) and actual problems like the one in https://github.com/jarun/googler/issues/21#issuecomment-187255335 with `-c fr`.

The test script can be a simple shell script, and once the CI is set up (which takes like two minutes), that won't be any extra maintenance burden, except we'll be alerted when something breaks, and we'll be able to stop regressions at bay.