### PR TITLE
googler.1: Correct description of option -C

### DIFF
--- a/googler.1
+++ b/googler.1
@@ -35,7 +35,7 @@ for Finnish.
 Open the first result in a web browser.
 .TP
 .B \-C
-Enable color output.
+Disable color output.
 .TP
 .BI \-t " dN"
 Time limit search [h5 (5 hrs), d5 (5 days), w5 (5 weeks), m5 (5 months), y5 (5 years)].


### PR DESCRIPTION
`-C` is for disabling color output, not the other way round.