### PR TITLE
README.md: Add Travis build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # googler
 
+[![Build Status](https://travis-ci.org/jarun/googler.svg?branch=master)](https://travis-ci.org/jarun/googler)
+
 ![Screenshot](googler.png)
 
 `googler` is a command-line power tool to search Google (Web & News) from the terminal. It shows the title, URL and text context for each result. Results are fetched in pages. Next or previous page navigation is possible using keyboard shortcuts. Results are indexed and a result URL can be opened in a browser using the index number. Supports sequential searches in a single instance.


### PR DESCRIPTION
Not sure if this is the best idea since there's a small chance that our tests can fail outside our control (i.e. Google blocking suspicious behavior), but it's usually good to have (rather than completely rely on notification emails which might get ignored amongst a sea of emails), and if we drop `[ci skip]` wisely in commit messages (there's no point in CI testing a commit that updates `README.md`, for instance), the chance will be pretty low.