### PR TITLE
Add HTTP proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Find `googler` useful? If you would like to donate, visit the
 - Supports Google search keywords like `filetype:mime`, `site:somesite.com` etc.
 - Optionally open the first result directly in browser (as in *I'm Feeling Lucky*)
 - Non-stop searches: fire new searches at omniprompt without exiting
+- Proxy support
 - Man page with examples, shell completion scripts for Bash, Zsh and Fish
 - Minimal dependencies
 
@@ -136,6 +137,8 @@ Please substitute `$version` with the appropriate package version.
       -t dN, --time dN      time limit search [h5 (5 hrs), d5 (5 days), w5 (5
                             weeks), m5 (5 months), y5 (5 years)]
       -w SITE, --site SITE  search a site using Google
+      -p PROXY, --proxy PROXY
+                            tunnel traffic through an HTTPS proxy (HOST:PORT)
       --json                output in JSON format; implies --noprompt
       --np, --noprompt      perform search and exit, do not prompt for further
                             interactions
@@ -286,7 +289,11 @@ Site specific search continues at omniprompt. Use the `g` key to run a regular G
         $ googler --colors bjdxxy google
         $ GOOGLER_COLORS=bjdxxy googler google
 
-15. More **help**:
+15. Tunnel traffic through an **HTTPS proxy**, e.g., a local Privoxy instance listening on port 8118:
+
+        $ googler --proxy localhost:8118 google
+
+16. More **help**:
 
         $ googler
         $ man googler

--- a/googler
+++ b/googler
@@ -495,9 +495,10 @@ class GoogleConnection(object):
 
     """
 
-    def __init__(self, host, port=None, timeout=45):
+    def __init__(self, host, port=None, timeout=45, proxy=None):
         self._host = None
         self._port = None
+        self._proxy = proxy
         self._conn = None
         self.new_connection(host, port=port, timeout=timeout)
 
@@ -522,16 +523,35 @@ class GoogleConnection(object):
         """
         if self._conn:
             self._conn.close()
+
         if not host:
             host = self._host
             port = self._port
         self._host = host
         self._port = port
-        logger.debug('Connecting to new host [%s]', host)
-        try:
+        host_display = host + (':%d' % port if port else '')
+
+        proxy = self._proxy
+        if proxy:
+            logger.debug('Connecting to proxy server %s', proxy)
+            self._conn = http.client.HTTPSConnection(proxy, timeout=timeout)
+
+            logger.debug('Tunneling to host %s' % host_display)
+            self._conn.set_tunnel(host, port=port)
+
+            try:
+                self._conn.connect()
+            except Exception as e:
+                msg = 'Failed to connect to proxy server %s: %s.' % (proxy, e)
+                raise GoogleConnectionError(msg)
+        else:
+            logger.debug('Connecting to new host %s', host_display)
             self._conn = http.client.HTTPSConnection(host, port=port, timeout=timeout)
-        except http.client.HTTPException as e:
-            raise GoogleConnectionError('Failed to connect to %s: %s.' % (host, e))
+            try:
+                self._conn.connect()
+            except Exception as e:
+                msg = 'Failed to connect to %s: %s.' % (host_display, e)
+                raise GoogleConnectionError(msg)
 
     def renew_connection(self, timeout=45):
         """Renew current connection.
@@ -611,7 +631,7 @@ class GoogleConnection(object):
         GoogleConnectionError
 
         """
-        logger.debug('Redirecting to URL [%s]', url)
+        logger.debug('Redirecting to URL %s', url)
         segments = urllib.parse.urlparse(url)
 
         host = segments.netloc
@@ -641,7 +661,7 @@ class GoogleConnection(object):
         http.client.HTTPException
 
         """
-        logger.debug('Fetching URL [%s]', url)
+        logger.debug('Fetching URL %s', url)
         self._conn.request('GET', url, None, {
             'Accept-Encoding': 'gzip',
             'User-Agent': USER_AGENT,
@@ -1409,7 +1429,8 @@ class GooglerCmd(object):
         self._opts = opts
 
         self._google_url = GoogleUrl(opts)
-        self._conn = GoogleConnection(self._google_url.hostname)
+        proxy = opts.proxy if hasattr(opts, 'proxy') else None
+        self._conn = GoogleConnection(self._google_url.hostname, proxy=proxy)
         atexit.register(self._conn.close)
 
         self.results = []
@@ -1775,6 +1796,8 @@ def parse_args(args=None, namespace=None):
            '[h5 (5 hrs), d5 (5 days), w5 (5 weeks), m5 (5 months), y5 (5 years)]')
     addarg('-w', '--site', dest='site', metavar='SITE',
            help='search a site using Google')
+    addarg('-p', '--proxy', dest='proxy',
+           help='tunnel traffic through an HTTPS proxy (HOST:PORT)')
     addarg('--json', dest='json', action='store_true',
            help='output in JSON format; implies --noprompt')
     addarg('--np', '--noprompt', dest='noninteractive', action='store_true',

--- a/googler.1
+++ b/googler.1
@@ -44,6 +44,9 @@ Time limit search [h5 (5 hrs), d5 (5 days), w5 (5 weeks), m5 (5 months), y5 (5 y
 .BI "-w, --site=" SITE
 Search a site using Google.
 .TP
+.BI "-p, --proxy=" PROXY
+Tunnel traffic through an HTTPS proxy. \fIPROXY\fR is of the form \fIHOST:PORT\fR. The proxy server must support HTTP CONNECT tunneling and must not block port 443 for the relevant Google hosts.
+.TP
 .BI "--json"
 Output in JSON format; implies \fB--noprompt\fR.
 .TP
@@ -286,6 +289,13 @@ Use a \fBcustom color scheme\fR, e.g., one warm color scheme designed for Solari
 .B googler --colors bjdxxy google
 .IP
 .B GOOGLER_COLORS=bjdxxy googler google
+.EE
+.IP 15. 4
+Tunnel traffic through an \fBHTTPS proxy\fR, e.g., a local Privoxy instance listening on port 8118:
+.PP
+.EX
+.IP
+.B googler --proxy localhost:8118 google
 .EE
 .PP
 .SH AUTHORS


### PR DESCRIPTION
**2016-06-05 Update.** Done, ready for testing, and not experimental.

---

Proxy support was requested in #20 and #35 (#35 is kind of ridiculous because there's no way we can "detect" proxy settings of, say, your browser;  you either explicitly supply a proxy, or make it system-wide in which case there's no detection required on our part). This is just a starting point.

**This PR does provide some insight into how we can improve the core**, mainly in terms of code deduplication. See `new_connection` and `google_get`.

Of course there are limitations:

* HTTP proxies only, SOCKS proxies not supported;
* No proxy username & password support, yet;
* I cannot really test it, because all free proxies I can find on the open web are blocked by Google.

Therefore, if you want to have proxy support, we need your help!

---

@jarun When I was coding this I noticed that `ua` header is missing from [this line](https://github.com/jarun/googler/blob/master/googler#L393). Could you please add it?

Of course a better approach is to factor out repeated code, as I mentioned above. See `google_get`.