### PR TITLE
Handle HTML entities in textual data

### DIFF
--- a/googler
+++ b/googler
@@ -31,15 +31,23 @@ import tempfile
 # Try to load Py3 modules, on error fall back to Py2 module names
 try:
     from io import BytesIO
+    from html.entities import name2codepoint
     import html.parser as HTMLParser
     from urllib.parse import urljoin, quote_plus, unquote
     from http.client import HTTPSConnection
 except ImportError:
     import StringIO
+    from htmlentitydefs import name2codepoint
     import HTMLParser
     from urlparse import urljoin
     from urllib import quote_plus, unquote
     from httplib import HTTPSConnection
+# Additional compatibility layer
+try:
+    unichr(0)
+except NameError:
+    # For Py3, use chr in place of unichr
+    unichr = chr
 
 
 # Global variables
@@ -72,6 +80,9 @@ class GoogleParser(HTMLParser.HTMLParser):
         self.handle_starttag = self.main_start
         self.handle_data = self.main_data
         self.handle_endtag = self.main_end
+        # Use stacks to keep track of the hirarchy of entityref/charref handlers
+        self.old_entityref_handlers = [self.handle_entityref]
+        self.old_charref_handlers = [self.handle_charref]
         self.results = []
 
     def main_start(self, tag, attrs):
@@ -94,6 +105,7 @@ class GoogleParser(HTMLParser.HTMLParser):
         if tag == "h3":
             self.handle_starttag = self.h3_start
             self.handle_data = self.h3_data
+            self.register_entityref_and_charref_handlers('title')
             self.handle_endtag = self.h3_end
         elif tag == "div" and len(attrs) > 0 and attrs[0] == ("class", "s"):
             self.handle_starttag = self.div_inner_start
@@ -140,6 +152,7 @@ class GoogleParser(HTMLParser.HTMLParser):
         if tag == "h3":
             self.handle_starttag = self.div_outer_start
             self.handle_data = self.div_outer_data
+            self.restore_entityref_and_charref_handlers()
             self.handle_endtag = self.div_outer_end
 
     # inner <div> ... </div>
@@ -147,6 +160,7 @@ class GoogleParser(HTMLParser.HTMLParser):
         if tag == "span" and len(attrs) > 0 and attrs[0] == ("class", "st"):
             self.handle_starttag = self.span_outer_start
             self.handle_data = self.span_outer_data
+            self.register_entityref_and_charref_handlers('text')
             self.handle_endtag = self.span_outer_end
 
     def div_inner_data(self, data):
@@ -159,6 +173,7 @@ class GoogleParser(HTMLParser.HTMLParser):
         if tag == "span" and len(attrs) > 0 and attrs[0] == ("class", "f"):
             self.handle_starttag = self.span_inner_start
             self.handle_data = self.span_inner_data
+            self.register_entityref_and_charref_handlers('text')
             self.handle_endtag = self.span_inner_end
 
     def span_outer_data(self, data):
@@ -168,6 +183,7 @@ class GoogleParser(HTMLParser.HTMLParser):
         if tag == "span":
             self.handle_starttag = self.div_outer_start
             self.handle_data = self.div_outer_data
+            self.restore_entityref_and_charref_handlers()
             self.handle_endtag = self.div_outer_end
 
     def span_inner_start(self, tag, start):
@@ -180,7 +196,47 @@ class GoogleParser(HTMLParser.HTMLParser):
         if tag == "span":
             self.handle_starttag = self.span_outer_start
             self.handle_data = self.span_outer_data
+            self.restore_entityref_and_charref_handlers()
             self.handle_endtag = self.span_outer_end
+
+    # Register entityref and charref handlers so that decoded refs are
+    # appended to the attribute (of self) named dest (e.g., 'title' or
+    # 'text').
+    def register_entityref_and_charref_handlers(self, dest):
+        self.old_entityref_handlers.append(self.handle_entityref)
+        self.old_charref_handlers.append(self.handle_charref)
+        self.handle_entityref = lambda ref: self.entityref(dest, ref)
+        self.handle_charref = lambda ref: self.charref(dest, ref)
+
+    def restore_entityref_and_charref_handlers(self):
+        self.handle_entityref = self.old_entityref_handlers.pop()
+        self.handle_charref = self.old_charref_handlers.pop()
+
+    def entityref(self, dest, ref):
+        try:
+            char = unichr(name2codepoint[ref])
+            setattr(self, dest, getattr(self, dest) + char)
+        except KeyError:
+            # Entity name not found; most likely rather sloppy HTML
+            # where a literal ampersand is not escaped; For instance,
+            # the HTML response returned by
+            #
+            #     googler -c au -l ko expected
+            #
+            # contains the following tag
+            #
+            #     <p class="_e4b"><a href="...">expected market return s&p 500</a></p>
+            #
+            # where &p is interpreted by HTMLParser as an entity (this
+            # behavior seems to be specific to Python 2.7).
+            setattr(self, dest, getattr(self, dest) + '&' + ref)
+
+    def charref(self, dest, ref):
+        if ref.startswith('x'):
+            char = unichr(int(ref[1:], 16))
+        else:
+            char = unichr(int(ref))
+        setattr(self, dest, getattr(self, dest) + char)
 
 
 class Result:


### PR DESCRIPTION
Fixes the issue where single quotes and double quotes are stripped from output (both result titles and result texts).

Before:

```
> googler -C double quotes </dev/null
 1 Quotation mark - Wikipedia, the free encyclopedia 
https://en.wikipedia.org/wiki/Quotation_mark
In American English, double quotes are used normally (the primary style). If quote marks are used inside another pair 
of quote marks, then single quotes are... 

 2 Single quotes or double quotes? Its really quite simple. - Slate 
http://www.slate.com/blogs/lexicon_valley/2014/10/21/single_quotes_or_double_quotes_it_s_really_quite_simple.html
Oct 21, 2014 - For several years now in teaching writing classes to college freshmen, Ive noticed some students adopt 
another rule: double quotes for long... 

 3 Quotation Marks: When to Use Double or Single Quotation ... 
https://www.scribendi.com/advice/when_to_use_double_or_single_quotation_marks.en.html
Quotations within the block will have double or single quotes, according to the convention being used (British or 
American). As usual, these different conventions... 

 4 Double Quotes - BrainyQuote 
http://www.brainyquote.com/quotes/keywords/double.html
Double Quotes from BrainyQuote, an extensive collection of quotations by famous authors, celebrities, and newsmakers. 

 5 Grammar Girl : Single Quotation Marks Versus Double ... 
http://www.quickanddirtytips.com/education/grammar/single-quotation-marks-versus-double-quotation-marks
Aug 18, 2011 - Double Quotation Marks for Scare Quotes. Double quotation marks can also be used sometimes to indicate 
that a word is special in some way. 

 6 When do you use double quotation marks? - APA Style 
http://www.apastyle.org/learn/faqs/use-double-quotes.aspx
Provides APA Style guidelines on when to use double quotation marks. 

 7 Quotation Marks - Capital Community College 
http://grammar.ccc.commnet.edu/grammar/marks/quotation.htm
My mothers favorite quote was from Shakespeare: This above all, to thine own .... In fact, single-quote marks and 
double-quote marks are apt to be reversed in... 

 8 Straight and curly quotes | Buttericks Practical Typography 
http://practicaltypography.com/straight-and-curly-quotes.html
Straight quotes are the two generic vertical quotation marks located near the return key: the straight single quote ( 
) and the straight double quote ( ). 

 9 Bash Reference Manual: Double Quotes - GNU 
https://www.gnu.org/s/bash/manual/html_node/Double-Quotes.html
Enclosing characters in double quotes ( ) preserves the literal value of all characters within the quotes, with the 
exception of $ , ` , \ , and, when history... 

Enter 'n', 'p', 'g keywords' or result number to continue: 
```

After:

```
> googler -C double quotes </dev/null
 1 Quotation mark - Wikipedia, the free encyclopedia 
https://en.wikipedia.org/wiki/Quotation_mark
In American English, double quotes are used normally (the "primary" style). If quote marks are used inside another 
pair of quote marks, then single quotes are ... 

 2 Single quotes or double quotes? It's really quite simple. - Slate 
http://www.slate.com/blogs/lexicon_valley/2014/10/21/single_quotes_or_double_quotes_it_s_really_quite_simple.html
Oct 21, 2014 - For several years now in teaching writing classes to college freshmen, I've noticed some students 
adopt another rule: double quotes for long ... 

 3 Quotation Marks: When to Use Double or Single Quotation ...›› 
https://www.scribendi.com/advice/when_to_use_double_or_single_quotation_marks.en.html
Quotations within the block will have double or single quotes, according to the convention being used (British or 
American). As usual, these different conventions ... 

 4 Double Quotes - BrainyQuote 
http://www.brainyquote.com/quotes/keywords/double.html
Double Quotes from BrainyQuote, an extensive collection of quotations by famous authors, celebrities, and newsmakers. 

 5 Grammar Girl : Single Quotation Marks Versus Double ... 
http://www.quickanddirtytips.com/education/grammar/single-quotation-marks-versus-double-quotation-marks
Aug 18, 2011 - Double Quotation Marks for Scare Quotes. Double quotation marks can also be used sometimes to indicate 
that a word is special in some way. 

 6 When do you use double quotation marks? - APA Style 
http://www.apastyle.org/learn/faqs/use-double-quotes.aspx
Provides APA Style guidelines on when to use double quotation marks. 

 7 Quotation Marks - Capital Community College 
http://grammar.ccc.commnet.edu/grammar/marks/quotation.htm
My mother's favorite quote was from Shakespeare: "This above all, to thine own .... In fact, single-quote marks and 
double-quote marks are apt to be reversed in ... 

 8 Straight and curly quotes | Butterick's Practical Typography 
http://practicaltypography.com/straight-and-curly-quotes.html
Straight quotes are the two generic vertical quotation marks located near the return key: the straight single quote ( 
' ) and the straight double quote ( " ). 

 9 Bash Reference Manual: Double Quotes - GNU 
https://www.gnu.org/s/bash/manual/html_node/Double-Quotes.html
Enclosing characters in double quotes (' " ') preserves the literal value of all characters within the quotes, with 
the exception of ' $ ', ' ` ', ' \ ', and, when history ... 

Enter 'n', 'p', 'g keywords' or result number to continue: 
```

Marked improvement! Although the code behind is really dirty.