### PR TITLE
README.md: Clarify supported Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you find `googler` useful, please consider donating via PayPal.
 - Skip links to Google News, Images or blank URLs in web search results
 - UTF-8 request and response
 - Fetch gzip compressed results
-- Works with Python 2.7.x and 3.x
+- Works with Python 2.7.x and 3.3.x or later
 - Enable/disable color output (default: colorful)
 - Enable/disable debug logs (default: disabled)
 - Manpage for quick reference
@@ -60,7 +60,7 @@ If you find `googler` useful, please consider donating via PayPal.
 
 # Installation
 
-`googler` requires Python 2.7.x or Python 3.x to work.
+`googler` requires Python to work. Officially supported Python versions are 2.7 and 3.3 or later (only the latest patch release of each minor version is supported).
 
 ## Installing from this repository
 


### PR DESCRIPTION
Apparently there's no reason to support outdated patch releases, so clarify that. The latest patch release of each minor version is what we test on the CI anyway.

As for Python 3.0, 3.1 and 3.2, these are partially broken transitional releases that are largely irrelevant now[^1] (might be less true for 3.2 since PyPy3 is still on CPython 3.2; but CPython is our only concern here). googler might work with them (we're still testing 3.2 on the CI, by the way), or not, we shouldn't care, factor into development or provide support for them.

[^1]: [According to Armin Ronacher](http://lucumr.pocoo.org/2013/5/21/porting-to-python-3-redux/) at least, back in 2013. Armin always gives good advice on Python; we should trust him.