### PR TITLE
Improve prompt message

### DIFF
--- a/googler
+++ b/googler
@@ -374,7 +374,7 @@ def quit(conn):
 def show_omniprompt():
     global colorize
 
-    message = "Enter 'n', 'p', keywords or result number to continue"
+    message = "Enter n, p, result number or new keywords"
     if colorize:
         return raw_input("\x1b[7m%s\x1b[0m " % message)
     else:


### PR DESCRIPTION
I just took a closer look at the prompt message and I think it could use some improvements.

1. 'n', 'p' and result number are all pertinent to the current search while keywords start a whole new, unrelated search, so 'n', 'p' and result number should be logically grouped together;

2. "Keywords" is rather confusing, because a user who isn't familiar with feature would naturally assume it's something related to the current search. "New keywords" is hopefully more clear.

The screenshot will have to be updated again if this is accepted...