### PR TITLE
Set encoding of standard streams to UTF-8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ matrix:
   allow_failures:
     - python: "nightly"
 script:
-  - PYTHONIOENCODING=utf-8 PATH=$PWD:$PATH ./test --ci
+  - PATH=$PWD:$PATH ./test --ci

--- a/googler
+++ b/googler
@@ -54,6 +54,11 @@ else:
     from urlparse import urljoin
     from httplib import HTTPSConnection
 
+    # Set the encoding of standard streams to UTF-8 (unnecessary for Python 3)
+    import codecs
+    sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
+    sys.stderr = codecs.getwriter('utf-8')(sys.stderr)
+
 
 # Global variables
 


### PR DESCRIPTION
Only necessary for Python 2. This way users don't need to have `PYTHONIOENCODING` set to `utf-8`. 

Also removed `PYTHONIOENCODING` from `.travis.yml`.

<del>I based this branch on #44 because it involves the compat layer (the actual change is acfc53c3c9f73775538932aa66427b6ddf99d883, which is very straightforward). Hence blocked on #44.</del>