### PR TITLE
Improve ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,16 +1,17 @@
-
 #### Bug reports
-  
-Please make sure you provide the following:
+
+Before opening an issue, please try to reproduce on [the latest developement version](https://github.com/jarun/googler#installing-from-this-repository) first. The bug you saw might have already been fixed.
+
+If the issue can be reproduced on master, then please make sure you provide the following:
 - Output of `googler -d`
 - Response body, something like `/tmp/googler-response-xxxxxx`
 - Details of operating system, Python version used, terminal emulator and shell
 - `locale` output, if relevant
-  
-If we need more information and there is no communication from the bug reporter with 7 days from the date of request, we will close the issue. If you have relevant information, resume discussion any time.
-  
-  
+
+If we need more information and there is no communication from the bug reporter within 7 days from the date of request, we will close the issue. If you have relevant information, resume discussion any time.
+
+
 #### Feature requests
 Please consider contributing the feature back to `googler` yourself. Feel free to discuss. We are more than happy to help.
 
----
+--- PLEASE DELETE THIS LINE AND EVERTHING ABOVE ---


### PR DESCRIPTION
* Ask to reproduce on master first;
* Ask to delete template text;
* "with 7 days" => "within 7 days";
* Universal newlines done right (that is, this file used to be checked in with hard CRLF, probably due to committing on Win32 without proper autocrlf setting; I have now changed newlines to LF, and since I have core.autocrlf set to input, it should propagate to native newlines on all OSes).