### PR TITLE
README.md: Add AUR and Homebrew badges to the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # googler
 
+[![AUR](https://img.shields.io/aur/version/googler.svg)](https://aur.archlinux.org/packages/googler)
+[![Homebrew](https://img.shields.io/homebrew/v/googler.svg)](http://braumeister.org/formula/googler)
+
 ![Screenshot](http://i.imgur.com/H2oDAg8.png)
 
 `googler` is a power tool to Google (Web & News) and Google Site Search from the terminal. It shows the title, URL and text context for each result, which can be directly opened in a browser from the terminal. Results are fetched in pages (with page navigation). Supports sequential searches in a single `googler` instance.


### PR DESCRIPTION
This way AUR or Homebrew users won't need to scrolldown to find out whether it's available. (Actually, a reasonably experienced user will just search or even guess from the command line; anyway, it doesn't hurt to make it obvious.)