### PR TITLE
Add setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.py.swp
+*.pyc
+*.swp
+dist
+build
+googler.egg-info
+*.swo
+profile
+.cache

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include *.md
+include googler.1
+include LICENSE
+include auto-completion/fish/googler.fish
+include auto-completion/bash/googler-completion.bash
+include auto-completion/zsh/_googler

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+from setuptools import setup
+import sys
+
+prefix = '/usr/local'
+for arg in sys.argv:
+    if '--prefix' in arg:
+        prefix = arg[arg.find('=') + 1:]
+
+setup(name='googler',
+      description='Google from the command-line',
+      long_description=open('README.md').read(),
+      version='2.3',
+      author='Arun Prakash Jana',
+      author_email='engineerarun@gmail.com',
+      url='https://github.com/jarun/googler',
+      data_files=[
+          (prefix + "/share/man/man1", ["googler.1"]),
+          (prefix + "/share/doc/googler", ["LICENSE"]),
+          (prefix + "/share/fish/vendor_completions.d",
+           ["auto-completion/fish/googler.fish"]),
+          ("/etc/bash_completion.d",
+              ["auto-completion/bash/googler-completion.bash"]),
+          (prefix + "/share/zsh/site-functions",
+              ["auto-completion/zsh/_googler"])
+      ],
+      scripts=['googler'],
+      classifiers=['Intended Audience :: End Users/Desktop',
+                   'Programming Language :: Python :: 2',
+                   'Programming Language :: Python :: 3'],
+      license='GPL3')


### PR DESCRIPTION
So I'm not sure why the makefile, nothing wrong with it ofc.
But I had some free time and figured I'd write a setup.py,
and maybe even throw it up on pypi. However that plan back
fired. It seems like `googler` is taken on pypi. That aside
if @jarun is cool with adding this an alt name could be
considered on pypi.


A small note, default `prefix` is `/usr/local` like the makefile.
I guess if its cool to add to project, the command to install would
be something like: `sudo python setup.py install --prefix=/usr` to
use `/usr/` over `/usr/local/` ofc.

Like I said nothing wrong with current install method. But pypi
permits people to install with some ease.