### PR TITLE
Build deb package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,24 @@ python:
 matrix:
   allow_failures:
     - python: "nightly"
+addons:
+  apt:
+    packages:
+      - debhelper
+      - devscripts
+      - zsh
 script:
   - ./tests/ci-test-wrapper --watch .travis.yml
+  - git fetch --tags origin
+  - ./tools/makedeb
+deploy:
+  provider: releases
+  api-key:
+    secure: GWdcYcZQMqM07QJ/AVYhfTrFWzoQKXvJLr/SWi0rjScnFyE7nWaUoevq+UtQqimTbwinMNmtfQZ6bKK44Vu/AfR9/ch6yr4x9tSSTcNhytaoCLkf3AyIBglMoyvoXCZSe1hO1p0exKNCLgI2IYmQhGjixgG/YauI5EDEWilFRT8oepKfClV9RoLOWpvu4mM5Ei3JwxUZlDdG86DLKvhIPGGLWFQoDsuCOJnGwc59lOWq+UOwQTuf2fSl1ItoE+y3l6U2D4akfh+2cjqhKfrxsD+klGtqR1WgyIhrhOXyIyAFvcFyIvwneMywJML6TgD8pD+v7RBhurdgFjetrQ0NUkC8EaGGzbSye7heXa6T/tsVvmpjQQGSLEDDby/BH52dpVl5JwuEJDRhRtFvPCrEroG7u3T3QIdW/OseCT8YaYl9i3C2qNgxr7lrEsrc6Ao4elV64nAiBbPXxD/+HEVQbUoa0ksYau4H0QTvRCtLE+iOYpkUMAM0e4PAthf52NPgV1jDDlGc51yY3fx+TtHFxYBzhTEEozss5haKJPGEsPf/jUAVVC+5OvVNPiMzxtwJJXv+sIRCh3qtS+FZnuevRKiiQHMFR+RWDZl6PI9XPnqdILpYn2bt5GNQZe3g6H9Rd06MnpWh90EGUxpeOOcxWYgy8z7ZlBANx9tak8Phal8=
+  file_glob: true
+  file: dist/*.deb
+  on:
+    repo: zmwangx/googler
+    tags: true
+    # Upload from only one job (doesn't matter which one because we're packaging the same thing throughout the matrix)
+    python: "2.7"

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 PREFIX=/usr/local
-BINDIR=$(PREFIX)/bin
-MANDIR=$(PREFIX)/share/man/man1
-DOCDIR=$(PREFIX)/share/doc/googler
+BINDIR=$(DESTDIR)$(PREFIX)/bin
+MANDIR=$(DESTDIR)$(PREFIX)/share/man/man1
+DOCDIR=$(DESTDIR)$(PREFIX)/share/doc/googler
 UNAME_S:=$(shell uname -s)
 
 
-.PHONY: install uninstall
+.PHONY: all install uninstall
+
+all:
 
 install:
 	install -m755 -d $(BINDIR)

--- a/tests/ci-test-wrapper
+++ b/tests/ci-test-wrapper
@@ -49,6 +49,12 @@ done
     exit 1
 }
 
+# Abort if the CI_SKIP_TEST environment variable is detected.
+if [[ -n $CI_SKIP_TEST ]]; then
+    printf 'Detected $CI_SKIP_TEST. Skipping tests.' >&2
+    exit
+fi
+
 # Diff HEAD against a base commit to see if the changes are worth
 # testing. (This check is kkipped entirely if the CI_FORCE_TEST environment
 # variable is set and non-nil.)

--- a/tools/makedeb
+++ b/tools/makedeb
@@ -8,13 +8,7 @@
 # Reference: https://wiki.debian.org/IntroDebianPackaging.
 
 setopt errexit noshwordsplit nobashrematch
-
-[[ $1 == (-h|--help) ]] && {
-    cat >&2 <<EOF
-Usage: $0:t [<commit-ish>]
-EOF
-}
-[[ -n $1 ]] && commitish=$1 || commitish=HEAD
+[[ -n $DEBUG ]] && setopt xtrace
 
 ################### SET UP ENVIRONMENT AND BASE DIRECTORIES ####################
 
@@ -33,6 +27,8 @@ export GIT_DIR=$repodir/.git
 ############################### HELPER FUNCTIONS ###############################
 
 print_error () print -R $'\e[31m'"Error: $*"$'\e[0m' >&2
+
+print_warning () print -R $'\e[33m'"Warning: $*"$'\e[0m' >&2
 
 # Usage: apt_package_version <package_name>
 apt_package_version () {
@@ -103,20 +99,68 @@ git_commitish_timestamp () {
     git rev-list --format=format:%ct --max-count=1 $1 | tail -n1
 }
 
-################################################################################
+######################### PARSE COMMAND LINE ARGUMENTS #########################
+
+tag_only=0
+while [[ $1 == -* ]]; do
+    case $1 in
+        -h|--help)
+            cat >&2 <<EOF
+Usage: $0:t [options] [<commit-ish>]
+
+Make a deb package from a git commit-ish, which defaults to HEAD.
+
+Options:
+    -h, --help
+        Print this help and exit.
+    --tag-only
+        Only make deb if HEAD (or <commit-ish>, if specified) is a tag or a
+        tagged commit.
+EOF
+            exit 1
+            ;;
+        --tag-only)
+            tag_only=1
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            print_error "Unknown option ${(q-)1}."
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+[[ -n $1 ]] && { commitish=$1; shift } || commitish=HEAD
+(( $# > 0 )) && {
+    print_error 'Unrecognized arguments' ${(q-)@}
+    exit 1
+}
+
+##################################### MAIN #####################################
 
 mkdir -p $builddir $distdir
 cd $builddir
 
-pkgname=googler
 normalized_commitish=$(git_normalize_commitish $commitish)
-creation_timestamp=$(git_commitish_timestamp $normalized_commitish)
+git_ref_is_tag $normalized_commitish && commitish_is_tag=1 || commitish_is_tag=0
+
+(( tag_only && !commitish_is_tag )) && {
+    print_warning "${(q-)commitish} is not a tag or tagged commit, skipping build."
+    exit
+}
+
+pkgname=googler
 version="${$(git describe --tags $commitish)#v}" # Quoting just to make sh-mode happy
 [[ -n $version ]] || {
     print_error 'Failed to extract version information.'
     exit 1
 }
 debrevision=1
+creation_timestamp=$(git_commitish_timestamp $normalized_commitish)
 
 upstream_tarball=$builddir/${pkgname}_${version}.orig.tar.gz
 buildsubdirname=${pkgname}-${version}
@@ -129,7 +173,7 @@ mkdir debian
 
 # Write debian/changelog
 
-if git_ref_is_tag $normalized_commitish; then
+if (( commitish_is_tag )); then
     # Tag -- point to the release
     changelog_url=https://github.com/jarun/googler/releases/tag/$normalized_commitish
 else

--- a/tools/makedeb
+++ b/tools/makedeb
@@ -1,0 +1,125 @@
+#!/usr/bin/env zsh
+
+# Automatically make .deb package from a commit or a tag.
+#
+# Prerequisites: zsh, build-essential, devscripts, debhelper (>= 9)
+#
+# Reference: https://wiki.debian.org/IntroDebianPackaging.
+
+setopt errexit noshwordsplit
+
+[[ $1 == (-h|--help) ]] && {
+    cat >&2 <<EOF
+Usage: $0:t [<commit-ish>]
+EOF
+}
+[[ -n $1 ]] && commitish=$1 || commitish=HEAD
+
+[[ -z $DEBFULLNAME ]] && DEBFULLNAME='Arun Prakash Jana'
+[[ -z $DEBEMAIL ]] && DEBEMAIL='arun@tuxdiary.com'
+export DEBFULLNAME DEBEMAIL
+
+here=$0:A:h
+repodir=$here/..
+builddir=$here/../build
+distdir=$here/../dist
+
+print_error () print -R $'\e[31m'"Error: $*"$'\e[0m' >&2
+
+mkdir -p $builddir $distdir
+cd $builddir
+
+pkgname=googler
+version="${$(git -C $repodir describe --tags $commitish)#v}" # Quoting just to make sh-mode happy
+[[ -n $version ]] || {
+    print_error 'Failed to extract version information.'
+    exit 1
+}
+debrevision=1
+
+upstream_tarball=$builddir/${pkgname}_${version}.orig.tar.gz
+buildsubdirname=${pkgname}-${version}
+git -C $repodir archive --format=tar.gz --prefix=$buildsubdirname/ --output=$upstream_tarball $commitish .
+rm -rf $buildsubdirname
+tar xf $upstream_tarball
+
+cd $buildsubdirname
+mkdir debian
+
+# Write debian/changelog
+# Use /bin/true as the dummy editor in order to avoid interactivity
+VISUAL=/bin/true dch --create -v ${version}-${debrevision} --package $pkgname
+
+# Write debian/compat
+cat >debian/compat <<'EOF'
+9
+EOF
+
+# Write debian/control
+cat >debian/control <<EOF
+Source: $pkgname
+Maintainer: $DEBFULLNAME <$DEBEMAIL>
+Section: misc
+Priority: optional
+Standards-Version: 3.9.7
+Build-Depends: debhelper (>= 9)
+
+Package: $pkgname
+Architecture: all
+Depends: \${shlibs:Depends}, \${misc:Depends}, python (>= 2.7)
+Description: Google Search and News from the command-line
+ See https://github.com/jarun/googler#readme.
+EOF
+
+# Write debian/copyright
+copyright_file=$builddir/$buildsubdirname/debian/copyright
+cat >debian/copyright <<EOF
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: $pkgname
+Upstream-Contact: $DEBFULLNAME <$DEBEMAIL>
+Source: https://github.com/jarun/googler
+
+Files: *
+Copyright: 2008 Henri Hakkinen
+           2015, 2016 Arun Prakash Jana
+License: GPL-3
+ This program is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License version 3 as published by the Free
+ Software Foundation.
+ .
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details.
+ .
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the full text of the GNU General Public License version 3
+ can be found in the file \`/usr/share/common-licenses/GPL-3'.
+EOF
+
+# Write debian/rules
+cat >debian/rules <<EOF
+#!/usr/bin/make -f
+%:
+	dh \$@
+
+override_dh_auto_install:
+	\$(MAKE) DESTDIR=\$\$(pwd)/debian/$pkgname PREFIX=/usr install
+	cp -p ${(q-)copyright_file} \$\$(pwd)/debian/$pkgname/usr/share/doc/$pkgname/copyright
+EOF
+chmod +x debian/rules
+
+# Write debian/source/format
+mkdir -p debian/source
+cat >debian/source/format <<'EOF'
+3.0 (quilt)
+EOF
+
+# Build binary package
+debuild -us -uc
+
+# Copying deb to dist
+binary_package=$builddir/${pkgname}_${version}-${debrevision}_all.deb
+cp -p $binary_package $distdir

--- a/tools/makedeb
+++ b/tools/makedeb
@@ -2,11 +2,12 @@
 
 # Automatically make .deb package from a commit or a tag.
 #
-# Prerequisites: zsh, build-essential, devscripts, debhelper (>= 9)
+# Prerequisites:
+#     zsh, build-essential, devscripts, debhelper (>= 9)
 #
 # Reference: https://wiki.debian.org/IntroDebianPackaging.
 
-setopt errexit noshwordsplit
+setopt errexit noshwordsplit nobashrematch
 
 [[ $1 == (-h|--help) ]] && {
     cat >&2 <<EOF
@@ -15,22 +16,102 @@ EOF
 }
 [[ -n $1 ]] && commitish=$1 || commitish=HEAD
 
+################### SET UP ENVIRONMENT AND BASE DIRECTORIES ####################
+
 [[ -z $DEBFULLNAME ]] && DEBFULLNAME='Arun Prakash Jana'
 [[ -z $DEBEMAIL ]] && DEBEMAIL='arun@tuxdiary.com'
-export DEBFULLNAME DEBEMAIL
+[[ -z $TZ ]] && TZ='Asia/Kolkata'
+export DEBFULLNAME DEBEMAIL TZ
 
 here=$0:A:h
 repodir=$here/..
 builddir=$here/../build
 distdir=$here/../dist
 
+export GIT_DIR=$repodir/.git
+
+############################### HELPER FUNCTIONS ###############################
+
 print_error () print -R $'\e[31m'"Error: $*"$'\e[0m' >&2
+
+# Usage: apt_package_version <package_name>
+apt_package_version () {
+    local version="${$(apt-cache show $1 | grep '^Version')#Version: }" || {
+        print_error "Version info not available for package ${(q-)1}."
+        exit 1
+    }
+    printf %s $version
+}
+
+debian_policy_version () {
+    local full_version="$(apt_package_version debian-policy)"
+    local match
+    [[ $full_version =~ ^(([0-9]+\.){2}[0-9]+) ]] || {
+        print_error "Invalid debian-policy version ${(q-)full_version}."
+        exit 1
+    }
+    printf %s $match[1]
+}
+
+# Git helpers
+
+# Usage: git_normalize_commitish <commit-ish>
+#
+# Normalize a commit-ish to a tag name if the commit-ish refers to a tag or
+# tagged commit; otherwise to a SHA (via git-rev-parse).
+git_normalize_commitish () {
+    local tagname commitsha
+    if tagname=$(git describe --exact --tags $1 2>/dev/null); then
+        printf %s $tagname
+    else
+        commitsha=$(git rev-parse --verify --quite $1) || {
+            print_error "Unable to parse ${(q-)1} as a git commit."
+            exit 1
+        }
+        printf %s $commitsha
+    fi
+}
+
+# Usage: git_ref_is_tag <refname>
+#
+# Returns 0 (is tag) or 1 (not tag).
+git_ref_is_tag () {
+    git show-ref --quiet --verify refs/tags/$1
+}
+
+# Usage: git_commitish_timestamp <normalized_commitish>
+#
+# Expects a normalized commit-ish (see git_normalize_commitish) as input, and
+# outputs a timestamp. For a tag, the timestamp is the tagger date. For a
+# commit, the timestamp is the committer date.
+git_commitish_timestamp () {
+    if git_ref_is_tag $1; then
+        local date="$(git for-each-ref --format='%(taggerdate)' refs/tags/$1)"
+
+        # The date returned by git-for-each-ref looks like `Sat Apr 23 10:38:27
+        # 2016 +0530', which isn't recognized by date(1) from coreutils. Need a
+        # hack to turn `+0530' into `U+0530' (same for -).
+        #
+        # Note that date will be empty if the tag at question is a lightweight
+        # tag (i.e., non-annotated) because they don't carry any tagger
+        # information; in that case we simply fall back to the committer.
+        if [[ -n $date ]]; then
+            date -d ${${date// -/ U-}// +/ U+} +%s
+            return
+        fi
+    fi
+    git rev-list --format=format:%ct --max-count=1 $1 | tail -n1
+}
+
+################################################################################
 
 mkdir -p $builddir $distdir
 cd $builddir
 
 pkgname=googler
-version="${$(git -C $repodir describe --tags $commitish)#v}" # Quoting just to make sh-mode happy
+normalized_commitish=$(git_normalize_commitish $commitish)
+creation_timestamp=$(git_commitish_timestamp $normalized_commitish)
+version="${$(git describe --tags $commitish)#v}" # Quoting just to make sh-mode happy
 [[ -n $version ]] || {
     print_error 'Failed to extract version information.'
     exit 1
@@ -47,8 +128,25 @@ cd $buildsubdirname
 mkdir debian
 
 # Write debian/changelog
-# Use /bin/true as the dummy editor in order to avoid interactivity
-VISUAL=/bin/true dch --create -v ${version}-${debrevision} --package $pkgname
+
+if git_ref_is_tag $normalized_commitish; then
+    # Tag -- point to the release
+    changelog_url=https://github.com/jarun/googler/releases/tag/$normalized_commitish
+else
+    # Just a commit -- point to the list of commits in the tree
+    changelog_url=https://github.com/jarun/googler/commits/$normalized_commitish
+fi
+cat >debian/changelog <<EOF
+$pkgname (${version}-${debrevision}) UNRELEASED; urgency=medium
+
+  * See full changelog at
+    $changelog_url
+
+ -- $DEBFULLNAME <$DEBEMAIL>  $(date --rfc-2822 --date=@$creation_timestamp)
+EOF
+
+# Alternatively, use dch to create changelog interactively:
+#     dch --create -v ${version}-${debrevision} --package $pkgname
 
 # Write debian/compat
 cat >debian/compat <<'EOF'
@@ -61,7 +159,7 @@ Source: $pkgname
 Maintainer: $DEBFULLNAME <$DEBEMAIL>
 Section: misc
 Priority: optional
-Standards-Version: 3.9.7
+Standards-Version: $(debian_policy_version)
 Build-Depends: debhelper (>= 9)
 
 Package: $pkgname

--- a/tools/makedeb
+++ b/tools/makedeb
@@ -24,6 +24,13 @@ distdir=$here/../dist
 
 export GIT_DIR=$repodir/.git
 
+################################# SET UP TRAPS #################################
+
+# Trap SIGUSR1: Abort program when functions called from within command
+# substitutions in heredocs fail.
+trap 'print_error "Encountered problem inside cmdsubst at line $LINENO."; exit 1' SIGUSR1
+export NOTIFY_PID=$$
+
 ############################### HELPER FUNCTIONS ###############################
 
 print_error () print -R $'\e[31m'"Error: $*"$'\e[0m' >&2
@@ -34,6 +41,7 @@ print_warning () print -R $'\e[33m'"Warning: $*"$'\e[0m' >&2
 apt_package_version () {
     local version="${$(apt-cache show $1 | grep '^Version')#Version: }" || {
         print_error "Version info not available for package ${(q-)1}."
+        [[ -n $NOTIFY_PID ]] && kill -SIGUSR1 $NOTIFY_PID
         exit 1
     }
     printf %s $version
@@ -44,6 +52,7 @@ debian_policy_version () {
     local match
     [[ $full_version =~ ^(([0-9]+\.){2}[0-9]+) ]] || {
         print_error "Invalid debian-policy version ${(q-)full_version}."
+        [[ -n $NOTIFY_PID ]] && kill -SIGUSR1 $NOTIFY_PID
         exit 1
     }
     printf %s $match[1]
@@ -62,6 +71,7 @@ git_normalize_commitish () {
     else
         commitsha=$(git rev-parse --verify --quite $1) || {
             print_error "Unable to parse ${(q-)1} as a git commit."
+            [[ -n $NOTIFY_PID ]] && kill -SIGUSR1 $NOTIFY_PID
             exit 1
         }
         printf %s $commitsha


### PR DESCRIPTION
I have improved my deb package building script and figured out uploading from Travis to GitHub releases. If you are interested in one more installation channel, this is almost ready to be integrated. (By the way, I doubt that googler could make its way into Debian's official repositories, so IMO either this or a PPA is the best we can do.)

My script can build a deb package off any commit-ish, and .travis.yml has been set up to upload the artifact to each pushed tag. Here is an example uploaded automatically from https://travis-ci.org/zmwangx/googler/jobs/126560102:

- https://github.com/zmwangx/googler/releases/tag/v2.4-testdeb
- https://github.com/zmwangx/googler/releases/download/v2.4-testdeb/googler_2.4-testdeb-1_amd64.deb

(**Update**: See https://github.com/jarun/googler/pull/67#issuecomment-215627032 for something better.)

**Note that this PR cannot be merged as is.** All commits except the `.travis.yml` one are ready, but `.travis.yml` needs to be adapted to use your API token and upload from `jarun/googler` instead of `zmwangx/googler`. I believe all you need to do is to [create a token](https://github.com/settings/tokens) with `public_repo` access, encrypt the token with [Travis's CLI client](https://github.com/travis-ci/travis.rb#installation):

    travis encrypt -r jarun/googler $TOKEN

and replace the current ciphertext with the ciphertext you get.