### PR TITLE
Add a non-interactive mode (--noprompt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Please substitute `$version` with the appropriate package version.
       -t dN, --time dN      time limit search [h5 (5 hrs), d5 (5 days), w5 (5
                             weeks), m5 (5 months), y5 (5 years)]
       -w SITE, --site SITE  search a site using Google
+      --np, --noprompt      perform search and exit, do not prompt for further
+                            interactions
       -d, --debug           enable debugging
 
     omniprompt keys:

--- a/googler
+++ b/googler
@@ -746,7 +746,7 @@ def fetch_results():
     for r in results:
         r.print_entry()
 
-    if skipped:
+    if skipped and not noninteractive:
         if skipped == 1:
             printerr("%d ad skipped." % skipped)
         else:

--- a/googler
+++ b/googler
@@ -122,6 +122,8 @@ debug = False     # Print debug logs
 news = False      # Read news
 exact = False     # If True, disable automatic spelling correction
 insite = None     # Google search a specific site
+noninteractive = False
+                  # Non-interactive mode
 server = "www.google.com"
 ua = ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
       '(KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240')
@@ -616,6 +618,8 @@ addarg('-t', '--time', dest='duration', type=is_duration, metavar='dN',
        '[h5 (5 hrs), d5 (5 days), w5 (5 weeks), m5 (5 months), y5 (5 years)]')
 addarg('-w', '--site', dest='insite', metavar='SITE',
        help='search a site using Google')
+addarg('--np', '--noprompt', dest='noninteractive', action='store_true',
+       help='perform search and exit, do not prompt for further interactions')
 addarg('-d', '--debug', dest='debug', action='store_true',
        help='enable debugging')
 addarg('keywords', nargs='+', metavar='KEYWORD',
@@ -641,6 +645,7 @@ duration = args.duration
 debug = args.debug
 keywords = args.keywords
 insite = args.insite
+noninteractive = args.noninteractive
 
 # Get terminal width
 columns, _ = get_terminal_size()
@@ -756,6 +761,9 @@ results = []
 while True:
     if nav == "n" or nav == "p" or nav == "g":
         results = fetch_results()
+
+    if noninteractive:
+        break
 
     oldstart = start
     try:

--- a/googler
+++ b/googler
@@ -112,7 +112,7 @@ columns = None    # Terminal window size.
 start = "0"       # The first result to display (option -s)
 num = None        # Number of results to display (option -n)
 lang = None       # Language to search for (option -l)
-openUrl = False   # If True, opens the first URL in browser (option -j)
+open_url = False  # If True, opens the first URL in browser (option -j)
 colorize = True   # If True, colorizes the output (option -C)
 duration = None   # Time limit search (option -t) [e.g. h5, d5, w5, m5, y5]
 conn = None       # Use a single global connection during navigation
@@ -321,7 +321,7 @@ class Result:
         text = self.text
 
         # Open the URL in a web browser if option -j was specified.
-        if openUrl:
+        if open_url:
             self.open()
             quit(conn)
 
@@ -609,7 +609,7 @@ addarg('-x', '--exact', dest='exact', action='store_true',
        help='disable automatic spelling correction')
 addarg('-C', '--nocolor', dest='colorize', action='store_false',
        help='disable color output')
-addarg('-j', '--first', '--lucky', dest='openUrl', action='store_true',
+addarg('-j', '--first', '--lucky', dest='open_url', action='store_true',
        help='open the first result in a web browser')
 addarg('-t', '--time', dest='duration', type=is_duration, metavar='dN',
        help='time limit search '
@@ -636,7 +636,7 @@ if args.tld:
 lang = args.lang
 exact = args.exact
 colorize = args.colorize
-openUrl = args.openUrl
+open_url = args.open_url
 duration = args.duration
 debug = args.debug
 keywords = args.keywords

--- a/googler.1
+++ b/googler.1
@@ -41,6 +41,9 @@ Time limit search [h5 (5 hrs), d5 (5 days), w5 (5 weeks), m5 (5 months), y5 (5 y
 .BI "-w, --site=" SITE
 Search a site using Google.
 .TP
+.BI "--np, --noprompt"
+Perform search and exit; do not prompt for further interactions.
+.TP
 .BI "-d, --debug"
 Enable debugging.
 .SH OMNIPROMPT KEYS

--- a/tests/test
+++ b/tests/test
@@ -93,17 +93,17 @@ test_googler () {
         printf 'failed with status %d.\033[0m\n' $last_status >&2
         exitcode=1
 
-        (( rerun )) && { googler -d "$@" </dev/null; printf '\n\033[33m[Exit status] %d\033[0m\n' $?; } || :
+        (( rerun )) && { googler --noprompt -d "$@"; printf '\n\033[33m[Exit status] %d\033[0m\n' $?; } || :
     }
 
     declare -g quiet
     if (( quiet )); then
-        googler -d "$@" </dev/null &>/dev/null || report_error --rerun "$@"
+        googler --noprompt -d "$@" &>/dev/null || report_error --rerun "$@"
     else
         printf '\033[34m==> googler ' >&2
         printf '%q ' "$@" >&2
         printf '\033[0m\n' >&2
-        googler -d "$@" </dev/null || report_error "$@"
+        googler --noprompt -d "$@" || report_error "$@"
         echo
     fi
 }


### PR DESCRIPTION
Perform the given search and exit. No more prompts and/or interactions.

Good for scripting, but also useful in an interactive shell for those we don't typically look at results on the second page.

Fixes #72.

I also renamed `openUrl` to `open_url` for consistency (noticed this when I was looking at how a I'm feeling lucky search breaks the loop).