### PR TITLE
Add omniprompt command "o"

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Please substitute `$version` with the appropriate package version.
       g keywords            initiate a new Google search for 'keywords' with original options
       n, p                  fetch next or previous set of search results
       index                 open the result corresponding to index in browser
+      o                     open the current search in browser
       q, Enter              exit googler (same behaviour for an empty search)
       *                     any other string initiates a new search with original options
       ?                     show omniprompt help
@@ -227,7 +228,7 @@ Site specific search continues at omniprompt. Use the `g` key to run a regular G
 
         alias define='googler -n 2 define'
 
-11. Look up `n`, `p`, `q`, `g keywords` or an index string at the **omniprompt**: As the omniprompt recognizes `n`, `p`, `q`, `g` or index strings as commands, you need to prefix them with `g`, e.g.,
+11. Look up `n`, `p`, `o`, `q`, `g keywords` or an index string at the **omniprompt**: As the omniprompt recognizes `n`, `p`, `o`, `q`, `g` or index strings as commands, you need to prefix them with `g`, e.g.,
 
         g n
         g g keywords

--- a/googler
+++ b/googler
@@ -788,7 +788,7 @@ def show_omniprompt():
 
     global colorize
 
-    message = "Enter n, p, result index or new keywords (? for help)"
+    message = "Enter n, p, o, result index or new keywords (? for help)"
     if colorize:
         return raw_input("\x1b[7m%s\x1b[0m " % message)
     else:
@@ -883,6 +883,7 @@ class ExtendedArgumentParser(argparse.ArgumentParser):
           g keywords            initiate a new Google search for 'keywords' with original options
           n, p                  fetch next or previous set of search results
           index                 open the result corresponding to index in browser
+          o                     open the current search in browser
           q, Enter              exit googler (same behaviour for an empty search)
           *                     any other string initiates a new search with original options
           ?                     show omniprompt help
@@ -1123,6 +1124,8 @@ while True:
         else:
             start = str(int(start) - 10)
         printerr("")
+    elif nav == "o":
+        open_url("https://" + server + url)
     elif nav == "q":
         break
     elif nav == "?":

--- a/googler.1
+++ b/googler.1
@@ -60,6 +60,9 @@ Fetch next or previous set of search results.
 .BI "index"
 Open the result corresponding to index in browser.
 .TP
+.BI "o"
+Open the current search in browser.
+.TP
 .BI "q, Enter"
 Exit googler.
 .TP
@@ -160,7 +163,7 @@ Alias to find \fBdefinitions of words\fR:
 .EE
 .PP
 .IP 11. 4
-Look up \fBn\fR, \fBp\fR, \fBq\fR, \fBg keywords\fR or an index string at the \fBomniprompt\fR: As the omniprompt recognizes \fBn\fR, \fBp\fR, \fBq\fR, \fBg\fR or index strings as commands, you need to prefix them with \fBg\fR, e.g.,
+Look up \fBn\fR, \fBp\fR, \fBo\fR, \fBq\fR, \fBg keywords\fR or an index string at the \fBomniprompt\fR: As the omniprompt recognizes \fBn\fR, \fBp\fR, \fBo\fR, \fBq\fR, \fBg\fR or index strings as commands, you need to prefix them with \fBg\fR, e.g.,
 .PP
 .EX
 .PD 0


### PR DESCRIPTION
For opening the current search (Google Search or News) in browser. For instance, using `o` within

    googler -d --time w2 --count 5 --lang de google

opens https://www.google.com/search?ie=UTF-8&oe=UTF-8&start=0&num=5&hl=de&tbs=qdr:w2&q=google.

This is very useful for development, and I can also see real world use cases for it.