### PR TITLE
Do not fetch previous page when already at the first page

### DIFF
--- a/googler
+++ b/googler
@@ -107,7 +107,7 @@ signal.signal(signal.SIGINT, sigint_handler)
 # Global variables
 
 columns = None              # Terminal window size.
-start = '0'                 # The first result to display (option -s)
+start = 0                   # The first result to display (option -s)
 num = None                  # Number of results to display (option -n)
 lang = None                 # Language to search for (option -l)
 lucky = False               # If True, opens the first URL in browser (option -j)
@@ -1057,10 +1057,10 @@ if len(sys.argv) < 2:
 args = argparser.parse_args()
 if args.start:
     if args.start > 0:
-        start = str(args.start)
+        start = args.start
 if args.num:
     if args.num > 0:
-        num = str(args.num)
+        num = args.num
 news = args.news
 if args.tld:
     server = server_url(args.tld)
@@ -1088,9 +1088,9 @@ debugp("Version %.1f" % _VERSION_)
 # Construct the query URL.
 url = "/search?ie=UTF-8&oe=UTF-8&"
 
-url += "start=" + start + "&"
+url += "start=" + str(start) + "&"
 if num is not None:
-    url += "num=" + num + "&"
+    url += "num=" + str(num) + "&"
 if news:
     url += "tbm=nws&"
 if lang is not None:
@@ -1206,26 +1206,26 @@ while True:
 
     if nav == "n":
         if num is not None:
-            start = str(int(start) + int(num))
+            start = start + num
         else:
-            start = str(int(start) + 10)
+            start = start + 10
 
-        url = url.replace("start=" + oldstart + "&", "start=" + start + "&", 1)
+        url = url.replace("start=" + str(oldstart) + "&", "start=" + str(start) + "&", 1)
         debugp("Next URL [%s]\n" % url)
         printerr("")
     elif nav == "p":
         newstart = 0
         if num is not None:
-            newstart = int(start) - int(num)
+            newstart = start - num
         else:
-            newstart = int(start) - 10
+            newstart = start - 10
 
         if newstart >= 0:
-            start = str(newstart)
+            start = newstart
         else:
             start = "0"
 
-        url = url.replace("start=" + oldstart + "&", "start=" + start + "&", 1)
+        url = url.replace("start=" + str(oldstart) + "&", "start=" + str(start) + "&", 1)
         debugp("Next URL [%s]\n" % url)
         printerr("")
     elif nav == "o":

--- a/googler
+++ b/googler
@@ -1214,7 +1214,11 @@ while True:
         debugp("Next URL [%s]\n" % url)
         printerr("")
     elif nav == "p":
-        newstart = 0
+        if start == 0:
+            printerr("Already at the first page.")
+            nav = "" # Unset nav so that we don't fetch result in the next iteration
+            continue
+
         if num is not None:
             newstart = start - num
         else:


### PR DESCRIPTION
If `start` is already 0, attempting to fetch "the previous page" just makes the same request all over again, which is a waste of resources. We just print an error message saying

    Already at the first page.

in this case.

I also made `start` and `num` ints. As always, see commit message for detailed rationale.