### PR TITLE
Reorder omniprompt help

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,14 +164,14 @@ Please substitute `$version` with the appropriate package version.
       -d, --debug           enable debugging
 
     omniprompt keys:
-      g keywords            initiate a new Google search for 'keywords' with original options
-      n, p                  fetch next or previous set of search results
+      n, p                  fetch the next or previous set of search results
       index                 open the result corresponding to index in browser
       f                     jump to the first page
       o                     open the current search in browser
+      g keywords            initiate a new Google search for 'keywords' with original options
       q, ^D                 exit googler
-      *                     any other string initiates a new search with original options
       ?                     show omniprompt help
+      *                     any other string initiates a new search with original options
 
 ## Configuration file
 

--- a/googler
+++ b/googler
@@ -966,14 +966,14 @@ class ExtendedArgumentParser(argparse.ArgumentParser):
     def print_omniprompt_help(file=None):
         file.write(textwrap.dedent("""
         omniprompt keys:
-          g keywords            initiate a new Google search for 'keywords' with original options
-          n, p                  fetch next or previous set of search results
+          n, p                  fetch the next or previous set of search results
           index                 open the result corresponding to index in browser
           f                     jump to the first page
           o                     open the current search in browser
+          g keywords            initiate a new Google search for 'keywords' with original options
           q, ^D                 exit googler
-          *                     any other string initiates a new search with original options
           ?                     show omniprompt help
+          *                     any other string initiates a new search with original options
         """))
 
     # Print information on googler

--- a/googler.1
+++ b/googler.1
@@ -51,11 +51,8 @@ Perform search and exit; do not prompt for further interactions.
 Enable debugging.
 .SH OMNIPROMPT KEYS
 .TP
-.BI g " keywords"
-Initiate a new Google search for \fIkeywords\fR with original options.
-.TP
 .BI "n, p"
-Fetch next or previous set of search results.
+Fetch the next or previous set of search results.
 .TP
 .BI "index"
 Open the result corresponding to index in browser.
@@ -66,14 +63,17 @@ Jump to the first page.
 .BI "o"
 Open the current search in browser.
 .TP
+.BI g " keywords"
+Initiate a new Google search for \fIkeywords\fR with original options.
+.TP
 .BI "q, ^D"
 Exit googler.
 .TP
-.BI *
-Any other string initiates a new search with original options.
-.TP
 .BI "?"
 Show omniprompt help.
+.TP
+.BI *
+Any other string initiates a new search with original options.
 .SH ENVIRONMENT
 .TP
 .BI BROWSER


### PR DESCRIPTION
1. Add an article for grammatical correctness;

2. "g keywords" pertains to a different query whereas n, p, index, f and o pertain to the current query; apparently commands operating on the current (and most often, initial) query should be grouped and prioritized;

3. "Any other string..." should appear last because otherwise "?" is included in "any other string"s.

