### PR TITLE
Customizable colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Find `googler` useful? If you would like to donate, visit the
 - [Usage](#usage)
     - [Cmdline options](#cmdline-options)
     - [Configuration file](#configuration-file)
+    - [Colors](#colors)
 - [Examples](#examples)
 - [Troubleshooting](#troubleshooting)
 - [Developers](#developers)
@@ -133,6 +134,7 @@ Please substitute `$version` with the appropriate package version.
       -l LANG, --lang LANG  display in language LANG
       -x, --exact           disable automatic spelling correction
       -C, --nocolor         disable color output
+      --colors COLORS       set output colors (see man page for details)
       -j, --first, --lucky  open the first result in a web browser
       -t dN, --time dN      time limit search [h5 (5 hrs), d5 (5 days), w5 (5
                             weeks), m5 (5 months), y5 (5 years)]
@@ -154,7 +156,7 @@ Please substitute `$version` with the appropriate package version.
 
 ## Configuration file
 
-`googler` doesn't have any! This is to retain the speed of the utility and avoid OS-specific differences. Users can enjoy the advantages of config files using aliases. There's no need to memorize options.
+`googler` doesn't have any! This is to retain the speed of the utility and avoid OS-specific differences. Users can enjoy the advantages of config files using aliases (with the exception of the color scheme, which can be additionally customized through an environment variable; see [Colors](#colors)). There's no need to memorize options.
 
 For example, the following alias for bash/zsh/ksh/etc.
 
@@ -166,6 +168,63 @@ The alias serves both the purposes of using config files:
 
 - Persistent settings: when the user invokes `g`, it expands to the preferred settings.
 - Override settings: thanks to the way Python `argparse` works, `googler` is written so that the settings in alias are completely overridden by any options passed from cli. So when the same user runs `g -l de -c de -n 12 hello world`, 12 results are returned from the Google Germany server, with preference towards results in German.
+
+## Colors
+
+`googler` allows you to customize the color scheme via a six-letter string, reminiscent of BSD `LSCOLORS`. The six letters represent the colors of
+
+- indices
+- titles
+- URLs
+- metadata/publishing info (Google News only)
+- abstracts
+- prompts
+
+respectively. The six-letter string is passed in either as the argument to the `--colors` option, or as the value of the environment variable `GOOGLER_COLORS`.
+
+We offer the following colors/styles:
+
+Letter | Color/Style
+------ | -----------
+a      | black
+b      | red
+c      | green
+d      | yellow
+e      | blue
+f      | magenta
+g      | cyan
+h      | white
+i      | bright black
+j      | bright red
+k      | bright green
+l      | bright yellow
+m      | bright blue
+n      | bright magenta
+o      | bright cyan
+p      | bright white
+A-H    | bold version of the lowercase-letter color
+I-P    | bold version of the lowercase-letter bright color
+x      | normal
+X      | bold
+y      | reverse video
+Y      | bold reverse video
+
+The default colors string is `GKlxxy`, which stands for
+
+- bold bright cyan indices
+- bold bright green titles
+- bright yellow URLs
+- normal metadata/publishing info
+- normal abstracts
+- reverse video prompts
+
+Note that
+
+- Bright colors (implemented as `\x1b[90m`–`\x1b[97m`) may not be available in all color-capable terminal emulators;
+- Some terminal emulators draw bold text in bright colors instead;
+- Some terminal emulators only distinguish between bold and bright colors via a default-off switch.
+
+Please consult the manual of your terminal emulator as well as the [Wikipedia article](https://en.wikipedia.org/wiki/ANSI_escape_code) on ANSI escape sequences.
 
 # Examples
 
@@ -224,6 +283,11 @@ Site specific search continues at omniprompt. Use the `g` key to run a regular G
 13. **Pipe** output:
 
         $ googler -C hello world | tee output
+
+14. Use a **custom color scheme**, e.g., a warm color scheme designed for Solarized Dark ([screenshot](https://i.imgur.com/6L8VlfS.png)):
+
+        $ googler --colors bjdxxy google
+        $ GOOGLER_COLORS=bjdxxy googler google
 
 14. More **help**:
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ fetches 7 results from the Google Russia server, with preference towards results
 The alias serves both the purposes of using config files:
 
 - Persistent settings: when the user invokes `g`, it expands to the preferred settings.
-- Override settings: thanks to the way Python `getopt()` works, `googler` is written so that the settings in alias are completely overridden by any options passed from cli. So when the same user runs `g -l de -c de -n 12 hello world`, 12 results are returned from the Google Germany server, with preference towards results in German.
+- Override settings: thanks to the way Python `argparse` works, `googler` is written so that the settings in alias are completely overridden by any options passed from cli. So when the same user runs `g -l de -c de -n 12 hello world`, 12 results are returned from the Google Germany server, with preference towards results in German.
 
 # Examples
 

--- a/auto-completion/bash/googler-completion.bash
+++ b/auto-completion/bash/googler-completion.bash
@@ -12,7 +12,7 @@ _googler () {
     local -a opts opts_with_args
     opts=(-c --tld -C --nocolor -d --debug -j --first --lucky --json -l --lang
           -n --count -N --news --np --noprompt -s --start -t --time -w --site -x --exact)
-    opts_with_arg=(-c --tld -l --lang -n --count -s --start -t --time -w --site)
+    opts_with_arg=(-c --tld --colors -l --lang -n --count -s --start -t --time -w --site)
 
     # Do not complete non option names
     [[ $cur == -* ]] || return 1

--- a/auto-completion/fish/googler.fish
+++ b/auto-completion/fish/googler.fish
@@ -11,6 +11,7 @@ complete -c googler -s c -l tld    -r      --description 'country-specific searc
 complete -c googler -s l -l lang   -r      --description 'display in specified language'
 complete -c googler -s x -l exact          --description 'disable automatic spelling correction'
 complete -c googler -s C -l nocolor        --description 'disable color output'
+complete -c googler -l colors      -r      --description 'set output colors'
 complete -c googler -s j -l first -l lucky --description 'open the first result in a web browser'
 complete -c googler -s t -l time   -r      --description 'time limit search (h/d/w/m/y + number)'
 complete -c googler -s w -l site   -r      --description 'search a site using Google'

--- a/auto-completion/zsh/_googler
+++ b/auto-completion/zsh/_googler
@@ -10,7 +10,8 @@ setopt localoptions noshwordsplit noksharrays
 local -a args
 args=(
     '(-c --tld)'{-c,--tld}'[country-specific search with top-level domain]:top level domain without dot'
-    '(-C --nocolor)'{-C,--nocolor}'[disable color output]'
+    '(-C --nocolor --colors)'{-C,--nocolor}'[disable color output]'
+    '(-C --nocolor)--colors[set output colors]:six-letter string'
     '(-d --debug)'{-d,--debug}'[enable debugging]'
     '(-j --first --lucky)'{-j,--first,--lucky}'[open the first result in a web browser]'
     '(--json --np --noprompt)--json[output in JSON format; implies --noprompt]'

--- a/googler
+++ b/googler
@@ -19,6 +19,7 @@
 
 from __future__ import print_function
 import argparse
+import collections
 import gzip
 import io
 import os
@@ -104,6 +105,21 @@ def sigint_handler(signum, frame):
 signal.signal(signal.SIGINT, sigint_handler)
 
 
+# Constants
+
+COLORMAP = {k: '\x1b[%sm' % v for k, v in {
+    'a': '30', 'b': '31', 'c': '32', 'd': '33',
+    'e': '34', 'f': '35', 'g': '36', 'h': '37',
+    'i': '90', 'j': '91', 'k': '92', 'l': '93',
+    'm': '94', 'n': '95', 'o': '96', 'p': '97',
+    'A': '30;1', 'B': '31;1', 'C': '32;1', 'D': '33;1',
+    'E': '34;1', 'F': '35;1', 'G': '36;1', 'H': '37;1',
+    'I': '90;1', 'J': '91;1', 'K': '92;1', 'L': '93;1',
+    'M': '94;1', 'N': '95;1', 'O': '96;1', 'P': '97;1',
+    'x': '0', 'X': '1', 'y': '7', 'Y': '7;1',
+}.items()}
+
+
 # Global variables
 
 columns = None              # Terminal window size.
@@ -112,6 +128,7 @@ num = None                  # Number of results to display (option -n)
 lang = None                 # Language to search for (option -l)
 lucky = False               # If True, opens the first URL in browser (option -j)
 colorize = True             # If True, colorizes the output (option -C)
+colors = None               # Colors object, set after reading color settings (option --colors)
 duration = None             # Time limit search (option -t) [e.g. h5, d5, w5, m5, y5]
 conn = None                 # Use a single global connection during navigation
 nav = 'n'                   # For user navigation
@@ -127,6 +144,8 @@ ua = ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
                             # Set user agent as Microsoft Edge
 _VERSION_ = 2.4             # Current version
 
+
+# Classes
 
 def annotate_tag(annotated_starttag_handler):
     # See parser logic within the GoogleParser class for documentation.
@@ -675,17 +694,28 @@ class Result:
 
     @staticmethod
     def print_title_and_url(index, title, url, indent=0):
+        global colorize, colors
         # Pad index and url with `indent` number of spaces
         index = " " * indent + str(index)
         url = " " * indent + url
         if colorize:
-            print("\x1B[1m\x1B[36m %s\x1B[92m %s\x1B[0m\n\x1B[93m%s\x1B[39m" % (index, title, url))
+            print(colors.index + index + colors.reset, end="")
+            print(' ' + colors.title + title + colors.reset)
+            print(colors.url + url + colors.reset)
         else:
             print(" %s %s\n%s" % (index, title, url))
 
     @staticmethod
-    def print_abstract(abstract, indent=0):
-        global columns
+    def print_metadata_and_abstract(abstract, metadata=None, indent=0):
+        global colorize, colors, columns
+        if metadata:
+            if colorize:
+                print(colors.metadata + metadata + colors.reset)
+            else:
+                print(metadata)
+
+        if colorize:
+            print(colors.abstract, end="")
         if columns > indent + 1:
             # Try to fill to columns
             fillwidth = columns - indent - 1
@@ -694,6 +724,8 @@ class Result:
             print("")
         else:
             print("%s\n" % abstract.replace("\n", " "))
+        if colorize:
+            print(colors.reset, end="")
 
     def print_entry(self):
         """Print an entry and returns an URL index.
@@ -719,20 +751,15 @@ class Result:
             self.open()
             quit(conn)
 
-        self.print_title_and_url(index, title, url)
         index_url_map[str(index)] = url
-
-        # Print metadata for Google News.
-        if metadata:
-            print(metadata)
-
-        self.print_abstract(abstract)
+        self.print_title_and_url(index, title, url)
+        self.print_metadata_and_abstract(abstract, metadata=metadata)
 
         subindex = 'a'
         for sitelink in sitelinks:
             fullindex = str(index) + subindex
             self.print_title_and_url(fullindex, sitelink.title, sitelink.url, indent=4)
-            self.print_abstract(sitelink.abstract, indent=4)
+            self.print_metadata_and_abstract(sitelink.abstract, indent=4)
             index_url_map[fullindex] = sitelink.url
             # Increment subindex
             subindex = chr(ord(subindex) + 1)
@@ -755,6 +782,9 @@ class Result:
         if self.sitelinks:
             obj['sitelinks'] = [sitelink.__dict__ for sitelink in self.sitelinks]
         return obj
+
+
+Colors = collections.namedtuple('Colors', 'index, title, url, metadata, abstract, prompt, reset')
 
 
 # Functions
@@ -872,11 +902,11 @@ def quit(conn):
 def show_omniprompt():
     """Show the search or navigation omniprompt."""
 
-    global colorize
+    global colorize, colors
 
     message = "googler (? for help)"
     if colorize:
-        return raw_input("\x1b[7m%s\x1b[0m " % message)
+        return raw_input(colors.prompt + message + colors.reset + ' ')
     else:
         return raw_input("%s: " % message)
 
@@ -1014,6 +1044,19 @@ def is_duration(arg):
         raise argparse.ArgumentTypeError('%s is not a valid duration' % arg)
     return arg
 
+def is_colorstr(arg):
+    """Check if a string is a valid color string."""
+    try:
+        assert len(arg) == 6
+        for c in arg:
+            assert c in COLORMAP
+    except AssertionError:
+        raise argparse.ArgumentTypeError('%s is not a valid color string' % arg)
+    return arg
+
+# Retrieve GOOGLER_COLORS
+colorstr_env = os.getenv('GOOGLER_COLORS')
+
 argparser = ExtendedArgumentParser(
     add_help=False,
     description='Google from the command-line.'
@@ -1034,6 +1077,9 @@ addarg('-x', '--exact', dest='exact', action='store_true',
        help='disable automatic spelling correction')
 addarg('-C', '--nocolor', dest='colorize', action='store_false',
        help='disable color output')
+addarg('--colors', dest='colorstr', default=colorstr_env if colorstr_env else 'GKlxxy',
+       type=is_colorstr, metavar='COLORS',
+       help='set output colors (see man page for details)')
 addarg('-j', '--first', '--lucky', dest='lucky', action='store_true',
        help='open the first result in a web browser')
 addarg('-t', '--time', dest='duration', type=is_duration, metavar='dN',
@@ -1068,6 +1114,7 @@ if args.tld:
 lang = args.lang
 exact = args.exact
 colorize = args.colorize
+colors = Colors(*map(lambda c: COLORMAP[c], args.colorstr), reset=COLORMAP['x'])
 lucky = args.lucky
 duration = args.duration
 if args.debug:

--- a/googler.1
+++ b/googler.1
@@ -32,6 +32,9 @@ Disable automatic spelling correction. Search exact keywords.
 .B "-C, --nocolor"
 Disable color output.
 .TP
+.BI "--colors=" COLORS
+Set output colors. Refer to the \fBCOLORS\fR section below for details.
+.TP
 .B "-j, --first, --lucky"
 Open the first result in a web browser. Feeling Lucky?
 .TP
@@ -74,6 +77,82 @@ Show omniprompt help.
 .TP
 .BI *
 Any other string initiates a new search with original options.
+.SH COLORS
+\fBgoogler\fR allows you to customize the color scheme via a six-letter string, reminiscent of BSD \fBLSCOLORS\fR. The six letters represent the colors of
+.IP - 2
+indices
+.PD 0 \" Change paragraph spacing to 0 in the list
+.IP - 2
+titles
+.IP - 2
+URLs
+.IP - 2
+metadata/publishing info (Google News only)
+.IP - 2
+abstracts
+.IP - 2
+prompts
+.PD 1 \" Restore paragraph spacing
+.TP
+respectively. The six-letter string is passed in either as the argument to the \fB--colors\fR option, or as the value of the environment variable \fBGOOGLER_COLORS\fR.
+.TP
+We offer the following colors/styles:
+.TS
+tab(;) box;
+l|l
+-|-
+l|l.
+Letter;Color/Style
+a;black
+b;red
+c;green
+d;yellow
+e;blue
+f;magenta
+g;cyan
+h;white
+i;bright black
+j;bright red
+k;bright green
+l;bright yellow
+m;bright blue
+n;bright magenta
+o;bright cyan
+p;bright white
+A-H;bold version of the lowercase-letter color
+I-P;bold version of the lowercase-letter bright color
+x;normal
+X;bold
+y;reverse video
+Y;bold reverse video
+.TE
+.TP
+.TP
+The default colors string is \fIGKlxxy\fR, which stands for
+.IP - 2
+bold bright cyan indices
+.PD 0 \" Change paragraph spacing to 0 in the list
+.IP - 2
+bold bright green titles
+.IP - 2
+bright yellow URLs
+.IP - 2
+normal metadata/publishing info
+.IP - 2
+normal abstracts
+.IP - 2
+reverse video prompts
+.PD 1 \" Restore paragraph spacing
+.TP
+Note that
+.IP - 2
+Bright colors (implemented as \\x1b[90m - \\x1b[97m) may not be available in all color-capable terminal emulators;
+.IP - 2
+Some terminal emulators draw bold text in bright colors instead;
+.IP - 2
+Some terminal emulators only distinguish between bold and bright colors via a default-off switch.
+.TP
+Please consult the manual of your terminal emulator as well as \fIhttps://en.wikipedia.org/wiki/ANSI_escape_code\fR for details.
 .SH ENVIRONMENT
 .TP
 .BI BROWSER
@@ -189,7 +268,6 @@ Input and output \fBredirection\fR:
 .PP
 .IP "" 4
 Note that \fI-C\fR is required to avoid printing control characters (for colored output).
-.PP
 .IP 13. 4
 \fBPipe\fR output:
 .PP
@@ -197,6 +275,16 @@ Note that \fI-C\fR is required to avoid printing control characters (for colored
 .IP
 .B googler -C hello world | tee output
 .EE
+.IP 14. 4
+Use a \fBcustom color scheme\fR, e.g., one warm color scheme designed for Solarized Dark:
+.PP
+.EX
+.IP
+.B googler --colors bjdxxy google
+.IP
+.B GOOGLER_COLORS=bjdxxy googler google
+.EE
+.PP
 .SH AUTHORS
 Henri Hakkinen
 .br


### PR DESCRIPTION
Example usage:

    > googler --colors bjdxxy google

or 

    > GOOGLER_COLORS=bjdxxy googler google

Screenshot:

![](https://i.imgur.com/6L8VlfS.png)