### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@ PREFIX ?= /usr/local
 BINDIR = $(DESTDIR)$(PREFIX)/bin
 MANDIR = $(DESTDIR)$(PREFIX)/share/man/man1
 DOCDIR = $(DESTDIR)$(PREFIX)/share/doc/googler
+BASHCOMPDIR = $(DESTDIR)$(PREFIX)/etc/bash_completion.d
+FISHCOMPDIR = $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d
+ZSHCOMPDIR = $(DESTDIR)$(PREFIX)/share/zsh/site-functions
 
-.PHONY: all install uninstall
+.PHONY: all install install.comp uninstall uninstall.comp
 
 all:
 
@@ -17,7 +20,16 @@ install:
 	install -m644 README.md $(DOCDIR)
 	rm -f googler.1.gz
 
+install.comp:
+	install -m755 -d $(BASHCOMPDIR) $(FISHCOMPDIR) $(ZSHCOMPDIR)
+	install -m644 auto-completion/bash/googler-completion.bash $(BASHCOMPDIR)
+	install -m644 auto-completion/fish/googler.fish $(FISHCOMPDIR)
+	install -m644 auto-completion/zsh/_googler $(ZSHCOMPDIR)
+
 uninstall:
 	rm -f $(BINDIR)/googler
 	rm -f $(MANDIR)/googler.1.gz
 	rm -rf $(DOCDIR)
+
+uninstall.comp:
+	rm -f $(BASHCOMPDIR)/googler-completion.bash $(FISHCOMPDIR)/googler.fish $(ZSHCOMPDIR)/_googler

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-PREFIX=/usr/local
-BINDIR=$(DESTDIR)$(PREFIX)/bin
-MANDIR=$(DESTDIR)$(PREFIX)/share/man/man1
-DOCDIR=$(DESTDIR)$(PREFIX)/share/doc/googler
-
+PREFIX ?= /usr/local
+BINDIR = $(DESTDIR)$(PREFIX)/bin
+MANDIR = $(DESTDIR)$(PREFIX)/share/man/man1
+DOCDIR = $(DESTDIR)$(PREFIX)/share/doc/googler
 
 .PHONY: all install uninstall
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ PREFIX=/usr/local
 BINDIR=$(DESTDIR)$(PREFIX)/bin
 MANDIR=$(DESTDIR)$(PREFIX)/share/man/man1
 DOCDIR=$(DESTDIR)$(PREFIX)/share/doc/googler
-UNAME_S:=$(shell uname -s)
 
 
 .PHONY: all install uninstall
@@ -14,16 +13,9 @@ install:
 	install -m755 -d $(MANDIR)
 	install -m755 -d $(DOCDIR)
 	gzip -c googler.1 > googler.1.gz
-	@if [ "$(UNAME_S)" = "Linux" ]; then\
-		install -m755 -t $(BINDIR) googler; \
-		install -m644 -t $(MANDIR) googler.1.gz; \
-		install -m644 -t $(DOCDIR) README.md; \
-	fi
-	@if [ "$(UNAME_S)" = "Darwin" ]; then\
-		install -m755  googler $(BINDIR); \
-		install -m644  googler.1.gz $(MANDIR); \
-		install -m644  README.md $(DOCDIR); \
-	fi
+	install -m755 googler $(BINDIR)
+	install -m644 googler.1.gz $(MANDIR)
+	install -m644 README.md $(DOCDIR)
 	rm -f googler.1.gz
 
 uninstall:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,15 @@ To remove `googler` and associated docs, run
 
 ### Shell completion
 
-Shell completion scripts for Bash, Fish and Zsh can be found in respective subdirectories of [`auto-completion/`](auto-completion). Please refer to your shell's manual for installation instructions.
+Shell completion scripts for Bash, Fish and Zsh can be found in respective subdirectories of [`auto-completion/`](auto-completion), and can be installed through
+
+    $ sudo make install.comp
+
+and uninstalled through
+
+    $ sudo make uninstall.comp
+
+Again, `PREFIX` is supported. Please refer to your shell's manual for instructions on setting up your shell to use completions.
 
 ## Installing with a package manager
 


### PR DESCRIPTION
See individual commit messages for details.

Most notably:

1. Support `PREFIX=/path/to/prefix make install` in addition to `make install PREFIX=/path/to/prefix`;
2. Add targets `install.comp` and `uninstall.comp` for completions. 