### PR TITLE
googler: Handle malformed HTML

### DIFF
--- a/googler
+++ b/googler
@@ -150,7 +150,11 @@ def retrieve_tag_annotation(annotated_endtag_handler):
     # Returns: HTMLParser.handle_endtag(self, tag: str) -> None
 
     def handler(self, tag):
-        annotation = self.tag_annotations[tag].pop()
+        try:
+            annotation = self.tag_annotations[tag].pop()
+        except IndexError:
+            # Malformed HTML -- more close tags than open tags
+            annotation = None
         annotated_endtag_handler(self, tag, annotation)
 
     return handler


### PR DESCRIPTION
Sometimes the response HTML could be malformed, with more closing tags than opening tags for a certain tag type. In this case there's nothing we could do other than ignoring it and assuming a None annotation.

Example:

    > googler -d -c nl -l en rupees

A sample response: https://goo.gl/J4QNnP

It has 444 opening `<div>` tags yet 445 closing `</div>` tags:

    > grep -o '<div' googler-response-uw83ptz1 | wc -l
    444
    > grep -o '</div>' googler-response-uw83ptz1 | wc -l
    445