### PR TITLE
Revert install.comp and uninstall.comp targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,8 @@ PREFIX ?= /usr/local
 BINDIR = $(DESTDIR)$(PREFIX)/bin
 MANDIR = $(DESTDIR)$(PREFIX)/share/man/man1
 DOCDIR = $(DESTDIR)$(PREFIX)/share/doc/googler
-BASHCOMPDIR = $(DESTDIR)$(PREFIX)/etc/bash_completion.d
-FISHCOMPDIR = $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d
-ZSHCOMPDIR = $(DESTDIR)$(PREFIX)/share/zsh/site-functions
 
-.PHONY: all install install.comp uninstall uninstall.comp
+.PHONY: all install uninstall
 
 all:
 
@@ -20,16 +17,7 @@ install:
 	install -m644 README.md $(DOCDIR)
 	rm -f googler.1.gz
 
-install.comp:
-	install -m755 -d $(BASHCOMPDIR) $(FISHCOMPDIR) $(ZSHCOMPDIR)
-	install -m644 auto-completion/bash/googler-completion.bash $(BASHCOMPDIR)
-	install -m644 auto-completion/fish/googler.fish $(FISHCOMPDIR)
-	install -m644 auto-completion/zsh/_googler $(ZSHCOMPDIR)
-
 uninstall:
 	rm -f $(BINDIR)/googler
 	rm -f $(MANDIR)/googler.1.gz
 	rm -rf $(DOCDIR)
-
-uninstall.comp:
-	rm -f $(BASHCOMPDIR)/googler-completion.bash $(FISHCOMPDIR)/googler.fish $(ZSHCOMPDIR)/_googler

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ PREFIX ?= /usr/local
 BINDIR = $(DESTDIR)$(PREFIX)/bin
 MANDIR = $(DESTDIR)$(PREFIX)/share/man/man1
 DOCDIR = $(DESTDIR)$(PREFIX)/share/doc/googler
-BASHCOMPDIR = $(DESTDIR)/etc/bash_completion.d
-FISHCOMPDIR = $(DESTDIR)/usr/share/fish/vendor_completions.d
-ZSHCOMPDIR = $(DESTDIR)/usr/share/zsh/site-functions
+BASHCOMPDIR = $(DESTDIR)$(PREFIX)/etc/bash_completion.d
+FISHCOMPDIR = $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d
+ZSHCOMPDIR = $(DESTDIR)$(PREFIX)/share/zsh/site-functions
 
 .PHONY: all install install.comp uninstall uninstall.comp
 

--- a/README.md
+++ b/README.md
@@ -89,15 +89,7 @@ To remove `googler` and associated docs, run
 
 ### Shell completion
 
-Shell completion scripts for Bash, Fish and Zsh can be found in respective subdirectories of [`auto-completion/`](auto-completion), and can be installed through
-
-    $ sudo make install.comp
-
-and uninstalled through
-
-    $ sudo make uninstall.comp
-
-Again, `PREFIX` is supported. Please refer to your shell's manual for instructions on setting up your shell to use completions.
+Shell completion scripts for Bash, Fish and Zsh can be found in respective subdirectories of [`auto-completion/`](auto-completion). Please refer to your shell's manual for installation instructions.
 
 ## Installing with a package manager
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ and uninstalled through
 
     $ sudo make uninstall.comp
 
-`DESTDIR` is supported. Please refer to your shell's manual for instructions on completion configuration.
+Again, `PREFIX` is supported. Please refer to your shell's manual for instructions on setting up your shell to use completions.
 
 ## Installing with a package manager
 


### PR DESCRIPTION
My points have been made clear in https://github.com/jarun/googler/commit/ebad612ee553dfef7a0e66eb34179e8c069ce503 and https://github.com/jarun/googler/pull/88#discussion_r64467089. To recap:

1. ca311b31440746151ebca0763c9c3c4ba4924225 was backed by [GNU Coding Standards on `sysconfdir`](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html) and [FHS](https://www.linuxbase.org/betaspecs/fhs/fhs/ch04s09.html).

2. One should not assume user shell's installation location, and should not assume a site install. Completion scripts should be kept relative to the program's installation location, not guessed shell locations (in particular, there's no standard location for bash completion scripts). `PREFIX` should be respected, and the ability to perform a user-local install or multiple installs on the same site should not be taken away.

Of course these points are somewhat subjective. But these are tried and true at least for me. I detest installation scripts that don't respect `PREFIX`.