### PR TITLE
Issue template: Clarify response body file and and ask users to upload it to a gist 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,10 +3,10 @@
 Before opening an issue, please try to reproduce on [the latest development version](https://github.com/jarun/googler#installing-from-this-repository) first. The bug you saw might have already been fixed.
 
 If the issue can be reproduced on master, then please make sure you provide the following:
-- Output of `googler -d`
-- Response body, something like `/tmp/googler-response-xxxxxx`
-- Details of operating system, Python version used, terminal emulator and shell
-- `locale` output, if relevant
+- Output of `googler -d`;
+- Link to the response body (you should see a line like `[DEBUG] Response body written to '/Volumes/ramdisk/googler-response-xxxxxxxx'` in the output of `googler -d`; please upload the file to a [gist](https://gist.github.com/) and include the gist's URL in the issue);
+- Details of operating system, Python version used, terminal emulator and shell;
+- `locale` output, if relevant.
 
 If we need more information and there is no communication from the bug reporter within 7 days from the date of request, we will close the issue. If you have relevant information, resume discussion any time.
 


### PR DESCRIPTION
Currently it is not very clear how to obtain the response body file.

Also, ask users to upload to a gist because

1. I love the service.

    I use the command line client [defunkt/gist](https://github.com/defunkt/gist) (`gist` on RubyGems), or rather, my own slightly enhanced fork [zmwangx/gist](https://github.com/zmwangx/gist), plus [jgorset/git.io](https://github.com/jgorset/git.io) (`git.io` on RubyGems);

2. Since our project is already GitHub-based <s>and users need to create an account to report issues</s>, git.io is a neutral value-add service.

3. Also avoid the blunder of user pasting the entire file to the issue body (definitely could happen with less seasoned users).