### PR TITLE
Baby step: Allow no keywords on the command line, and introduce -h, --help option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Please substitute `$version` with the appropriate package version.
       KEYWORD               search keywords
 
     optional arguments:
+      -h, --help            show this help message and exit
       -s N, --start N       start at the Nth result
       -n N, --count N       show N results (default 10)
       -N, --news            show results from news section

--- a/auto-completion/bash/googler-completion.bash
+++ b/auto-completion/bash/googler-completion.bash
@@ -10,7 +10,7 @@ _googler () {
     local IFS=$' \n'
     local cur=$2 prev=$3
     local -a opts opts_with_args
-    opts=(-c --tld -C --nocolor -d --debug -j --first --lucky --json -l --lang
+    opts=(-c --tld -C --nocolor -d --debug -h --help -j --first --lucky --json -l --lang
           -n --count -N --news --np --noprompt -s --start -t --time -w --site -x --exact)
     opts_with_arg=(-c --tld --colors -l --lang -n --count -s --start -t --time -w --site)
 

--- a/auto-completion/fish/googler.fish
+++ b/auto-completion/fish/googler.fish
@@ -4,6 +4,7 @@
 # Author:
 #   Arun Prakash Jana <engineerarun@gmail.com>
 #
+complete -c googler -s h -l help           --description 'show help text and exit'
 complete -c googler -s s -l start  -r      --description 'start at the Nth result'
 complete -c googler -s n -l count  -r      --description 'show specified number of results (default 10)'
 complete -c googler -s N -l news           --description 'show results from news section'

--- a/auto-completion/zsh/_googler
+++ b/auto-completion/zsh/_googler
@@ -9,6 +9,7 @@
 setopt localoptions noshwordsplit noksharrays
 local -a args
 args=(
+    '(- : *)'{-h,--help}'[show help text and exit]'
     '(-c --tld)'{-c,--tld}'[country-specific search with top-level domain]:top level domain without dot'
     '(-C --nocolor --colors)'{-C,--nocolor}'[disable color output]'
     '(-C --nocolor)--colors[set output colors]:six-letter string'

--- a/googler
+++ b/googler
@@ -1617,6 +1617,9 @@ class GooglerCmd(object):
         """Run REPL."""
         if self.keywords:
             self.fetch_and_display()
+        else:
+            printerr('Please initiate a query.')
+
         while True:
             self.read_next_command()
             # TODO: Automatic dispatcher
@@ -1645,7 +1648,7 @@ class GooglerCmd(object):
                     self.help()
                 elif cmd in self._urltable:
                     open_url(self._urltable[cmd])
-                elif cmd.isdigit() and int(cmd) < 100:
+                elif self.keywords and cmd.isdigit() and int(cmd) < 100:
                     printerr('Index out of bound. To search for the number, use g.')
                 else:
                     self.do_google(cmd)
@@ -1659,6 +1662,7 @@ class GooglerArgumentParser(argparse.ArgumentParser):
     # Print omniprompt help
     @staticmethod
     def print_omniprompt_help(file=None):
+        file = sys.stderr if file is None else file
         file.write(textwrap.dedent("""
         omniprompt keys:
           n, p                  fetch the next or previous set of search results
@@ -1674,6 +1678,7 @@ class GooglerArgumentParser(argparse.ArgumentParser):
     # Print information on googler
     @staticmethod
     def print_general_info(file=None):
+        file = sys.stderr if file is None else file
         file.write(textwrap.dedent("""
         Version %s
         Copyright (C) 2008 Henri Hakkinen
@@ -1764,10 +1769,7 @@ def parse_args(args=None, namespace=None):
 
     colorstr_env = os.getenv('GOOGLER_COLORS')
 
-    argparser = GooglerArgumentParser(
-        add_help=False,
-        description='Google from the command-line.'
-    )
+    argparser = GooglerArgumentParser(description='Google from the command-line.')
     addarg = argparser.add_argument
     addarg('-s', '--start', dest='start', type=argparser.nonnegative_int,
            default=0, metavar='N',
@@ -1804,16 +1806,12 @@ def parse_args(args=None, namespace=None):
            help='perform search and exit, do not prompt for further interactions')
     addarg('-d', '--debug', dest='debug', action='store_true',
            help='enable debugging')
-    addarg('keywords', nargs='+', metavar='KEYWORD',
+    addarg('keywords', nargs='*', metavar='KEYWORD',
            help='search keywords')
     return argparser.parse_args(args, namespace)
 
 
 def main():
-    if len(sys.argv) < 2:
-        GooglerArgumentParser.print_help(sys.stderr)
-        sys.exit(1)
-
     logger.debug('Version %s', _VERSION_)
 
     opts = parse_args()

--- a/googler.1
+++ b/googler.1
@@ -11,6 +11,9 @@ googler \- Google from the command-line
 is a command-line tool to search Google (Web & News) from the terminal. Google site search works too. \fBgoogler\fR shows the title, URL and text context for each result. Results are fetched in pages. Next or previous page navigation is possible using keyboard shortcuts. Results are indexed and a result URL can be opened in a browser using the index number. There is no configuration file as aliases serve the same purpose for this utility. Supports sequential searches in a single instance.
 .SH OPTIONS
 .TP
+.BI "-h, --help"
+Show help text and exit.
+.TP
 .BI "-s, --start=" N
 Start at the \fIN\fRth result.
 .TP


### PR DESCRIPTION
This is point 4 of https://github.com/jarun/googler/issues/87#issuecomment-221962173.

---

All the machinery is almost there, just need to flip the switch.

Instead of printing the help text when there's is no argument, we now support the standard `-h, --help` option, and a command line with no argument leads us into the REPL immediately.

Transcript of a sample session:

    > googler -C -w github.com -n 3
    Please initiate a query.
    googler (? for help): f
    Initiate a query first.
    googler (? for help): n
    Initiate a query first.
    googler (? for help): o
    Initiate a query first.
    googler (? for help): googler

     1 GitHub - jarun/googler: Google from the command-line
    https://github.com/jarun/googler
    Google from the command-line. Contribute to googler development by
    creating an account on GitHub.

     2 googler/googler.1 at master · jarun/googler · GitHub
    https://github.com/jarun/googler/blob/master/googler.1
    Google from the command-line. Contribute to googler development by
    creating an account on GitHub.

     3 googler/README.md at master · jarun/googler · GitHub
    https://github.com/jarun/googler/blob/master/README.md
    Google from the command-line. Contribute to googler development by
    creating an account on GitHub.

    googler (? for help): q

Also fixed a bug in `GooglerArgumentParser` where file is not being defaulted to `sys.stderr`.