### PR TITLE
Fix running from outside US

### DIFF
--- a/googler
+++ b/googler
@@ -603,6 +603,7 @@ class GoogleConnection(object):
             if 'sorry/IndexRedirect?' in redirection_url:
                 raise GoogleConnectionError('Connection blocked due to unusual activity.')
             self._redirect(redirection_url)
+            resp = self._resp
 
         if resp.status != 200:
             raise GoogleConnectionError('Got HTTP %d: %s' % (resp.status, resp.reason))


### PR DESCRIPTION
Previously, running googler from Germany resulted in an error:

    [ERROR] Got HTTP 302: Found

The fix is quite simple: Upon detecting a 302 (https://www.google.com/search... -> http://www.google.de/search... ), googler already correctly redirects to the new URL. However, after the redirect request has been sent, the old request was used before when going on. Instead, use the newly sent request.