### PR TITLE
Fix #114: disable user-agent and resurrect interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <a href="https://asciinema.org/a/46340"><img src="https://asciinema.org/a/46340.png" alt="Asciicast" width="734"/></a>
 </p>
 
-`googler` is a power tool to Google (Web & News) and Google Site Search from the terminal. It shows the title, URL and text context for each result, which can be directly opened in a browser from the terminal. Results are fetched in pages (with page navigation). Supports sequential searches in a single `googler` instance.
+`googler` is a power tool to Google (Web & News) and Google Site Search from the terminal. It shows the title, URL and abstract for each result, which can be directly opened in a browser from the terminal. Results are fetched in pages (with page navigation). Supports sequential searches in a single `googler` instance.
 
 `googler` isn't affiliated to Google in any way.
 

--- a/googler
+++ b/googler
@@ -1004,6 +1004,9 @@ class GoogleParser(html.parser.HTMLParser):
     #
     #   4. URLs are wrapped
     #   <a href="/url?q=http://...&sa=...">
+    #
+    #   5. URLs are quoted
+    #   'https://vk.com/doc206446660_429188746%3Fhash%3D6097a8b0a41185cb90%26dl%3D03c63c1be5c02e8620'
 
     def __init__(self, news=False):
         html.parser.HTMLParser.__init__(self)
@@ -1112,16 +1115,12 @@ class GoogleParser(html.parser.HTMLParser):
 
     @annotate_tag
     def title_start(self, tag, attrs):
-        if tag == 'span':
-            # Print a space after the filetype indicator
-            self.start_populating_textbuf(lambda text: text + ' ')
-            return 'title_filetype'
         if tag == 'a' and 'href' in attrs:
             self.url = attrs['href']
             try:
                 start = self.url.index('?q=') + len('?q=')
                 end = self.url.index('&sa=', start)
-                self.url = self.url[start:end]
+                self.url = urllib.parse.unquote_plus(self.url[start:end])
             except ValueError:
                 pass
             self.start_populating_textbuf()
@@ -1189,6 +1188,12 @@ class GoogleParser(html.parser.HTMLParser):
     def sitelink_title_start(self, tag, attrs):
         if tag == 'a' and 'href' in attrs:
             self.current_sitelink.url = attrs['href']
+            try:
+                start = self.current_sitelink.url.index('?q=') + len('?q=')
+                end = self.current_sitelink.url.index('&sa=', start)
+                self.current_sitelink.url = urllib.parse.unquote_plus(self.current_sitelink.url[start:end])
+            except ValueError:
+                pass
             self.start_populating_textbuf()
             return 'sitelink_title_link'
 

--- a/googler
+++ b/googler
@@ -698,7 +698,7 @@ class GoogleConnection(object):
         logger.debug('Fetching URL %s', url)
         self._conn.request('GET', url, None, {
             'Accept-Encoding': 'gzip',
-            'User-Agent': USER_AGENT,
+            #'User-Agent': USER_AGENT,
             'Cookie': self.cookie,
             'Connection': 'keep-alive',
             'DNT': '1',
@@ -966,7 +966,7 @@ class GoogleParser(html.parser.HTMLParser):
     #
     # Ignore List
     #
-    # - As good as our result criterions might be, sometimes results of
+    # - As good as our result criteria might be, sometimes results of
     #   dubious value (usually from Google's value-add features) slip
     #   through. The "People also ask" feature is a good example of this
     #   type (a sample query is "VPN"; see screenshot
@@ -988,6 +988,22 @@ class GoogleParser(html.parser.HTMLParser):
     #   title, etc.), and the scope is switched to 'ignore'. All
     #   descendants of the tag are ignored. When the corresponding end
     #   tag is finally reach, the former scope is restored.
+    #
+    #
+    # User Agent disabled (differences)
+    #
+    #   1. For Google News results, <div class="g"> is followed by <table> tag
+    #   <div class="g">
+    #       <table>
+    #
+    #   2. File mime type follows <div class="g">
+    #   <div class="g"><span style="float:left"><span class="mime">[PDF]</span>&nbsp;</span>
+    #
+    #   3. News metadata (source and time) comes within a single tag
+    #   <div class="slp"><span class="f">Reuters - 3 hours ago</span>
+    #
+    #   4. URLs are wrapped
+    #   <a href="/url?q=http://...&sa=...">
 
     def __init__(self, news=False):
         html.parser.HTMLParser.__init__(self)
@@ -1038,7 +1054,7 @@ class GoogleParser(html.parser.HTMLParser):
             self.set_handlers_to('result')
             return 'result'
 
-        # Ommitted results
+        # Omitted results
         if tag == 'p' and attrs.get('id') == 'ofr':
             self.filtered = True
 
@@ -1048,6 +1064,10 @@ class GoogleParser(html.parser.HTMLParser):
 
     @annotate_tag
     def result_start(self, tag, attrs):
+        if tag == 'span' and 'mime' in self.classes(attrs):
+            self.start_populating_textbuf()
+            return 'title_filetype'
+
         if not self.title_registered and tag == 'h3' and 'r' in self.classes(attrs):
             self.set_handlers_to('title')
             return 'title'
@@ -1056,14 +1076,15 @@ class GoogleParser(html.parser.HTMLParser):
             self.set_handlers_to('abstract')
             return 'abstract'
 
-        if not self.sitelinks and tag == 'table':
+        if not self.sitelinks and not self.news and tag == 'table':
             self.set_handlers_to('sitelink_table')
             return 'sitelink_table'
 
         if self.news:
             if not self.metadata_registered and tag == 'div' and 'slp' in self.classes(attrs):
                 # Change metadata field separator from '-' to ', ' for better appearance
-                self.start_populating_textbuf(lambda text: ', ' if text == '-' else text)
+                self.start_populating_textbuf(lambda text:
+                                              text.replace(' -', ',', 1) if ' - ' in text else text)
                 return 'news_metadata'
 
             if not self.abstract_registered and tag == 'div' and 'st' in self.classes(attrs):
@@ -1097,6 +1118,12 @@ class GoogleParser(html.parser.HTMLParser):
             return 'title_filetype'
         if tag == 'a' and 'href' in attrs:
             self.url = attrs['href']
+            try:
+                start = self.url.index('?q=') + len('?q=')
+                end = self.url.index('&sa=', start)
+                self.url = self.url[start:end]
+            except ValueError:
+                pass
             self.start_populating_textbuf()
             return 'title_link'
 
@@ -1355,7 +1382,7 @@ class Result(object):
         if columns > indent + 1:
             # Try to fill to columns
             fillwidth = columns - indent - 1
-            for line in textwrap.wrap(abstract, width=fillwidth):
+            for line in textwrap.wrap(abstract.replace('\n', ''), width=fillwidth):
                 print('%s%s' % (' ' * indent, line))
             print('')
         else:

--- a/googler
+++ b/googler
@@ -993,20 +993,26 @@ class GoogleParser(html.parser.HTMLParser):
     # User Agent disabled (differences)
     #
     #   1. For Google News results, <div class="g"> is followed by <table> tag
-    #   <div class="g">
-    #       <table>
+    #       <div class="g">
+    #           <table>
     #
     #   2. File mime type follows <div class="g">
-    #   <div class="g"><span style="float:left"><span class="mime">[PDF]</span>&nbsp;</span>
+    #       <div class="g"><span style="float:left"><span class="mime">[PDF]</span>&nbsp;</span>
     #
     #   3. News metadata (source and time) comes within a single tag
-    #   <div class="slp"><span class="f">Reuters - 3 hours ago</span>
+    #       <div class="slp"><span class="f">Reuters - 3 hours ago</span>
     #
     #   4. URLs are wrapped
-    #   <a href="/url?q=http://...&sa=...">
+    #       <a href="/url?q=http://...&sa=...">
     #
     #   5. URLs are quoted
-    #   'https://vk.com/doc206446660_429188746%3Fhash%3D6097a8b0a41185cb90%26dl%3D03c63c1be5c02e8620'
+    #       'https://vk.com/doc206446660_429188746%3Fhash%3D6097a8b0a41185cb90%26dl%3D03c63c1be5c02e8620'
+    #
+    #   6. Google Services links are returned as regular results,
+    #      start with '/search?q=' but no following 'http' or 'https'
+    #       <div class="g">
+    #           <div>
+    #               <h3 class="r"><a href="/search?q=india&...&sa=...">News for <b>india</b></a></h3>
 
     def __init__(self, news=False):
         html.parser.HTMLParser.__init__(self)
@@ -1116,6 +1122,10 @@ class GoogleParser(html.parser.HTMLParser):
     @annotate_tag
     def title_start(self, tag, attrs):
         if tag == 'a' and 'href' in attrs:
+            # Skip 'News for', 'Images for' search links
+            if attrs['href'].startswith('/search'):
+                return
+
             self.url = attrs['href']
             try:
                 start = self.url.index('?q=') + len('?q=')


### PR DESCRIPTION
I will still consider this as experimental and not sure if it makes it to the next release. However the performance gains are considerable when user agent is disabled in the code. The network data transfer takes most of the time and this change impacts all of them. The profiling results below speak for themselves.

**With UA disabled and redirection**
```
$ python3 -m cProfile -s time ./googler hello --noprompt
...
         92398 function calls (91035 primitive calls) in 1.194 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       23    0.543    0.024    0.543    0.024 {method 'read' of '_ssl._SSLSocket' objects}
        2    0.214    0.107    0.214    0.107 {method 'do_handshake' of '_ssl._SSLSocket' objects}
        2    0.148    0.074    0.150    0.075 {built-in method _socket.getaddrinfo}
        2    0.085    0.043    0.085    0.043 {method 'connect' of '_socket.socket' objects}
        3    0.023    0.008    0.023    0.008 {built-in method _imp.create_dynamic}
        4    0.019    0.005    0.019    0.005 {built-in method builtins.compile}
     4730    0.012    0.000    0.012    0.000 {method 'match' of '_sre.SRE_Pattern' objects}
      638    0.012    0.000    0.041    0.000 parser.py:301(parse_starttag)
        1    0.008    0.008    0.069    0.069 parser.py:134(goahead)
       48    0.007    0.000    0.007    0.000 {built-in method marshal.loads}
      638    0.006    0.000    0.012    0.000 googler:729(handler)
     62/1    0.005    0.000    1.195    1.195 {built-in method builtins.exec}
```

**With UA disabled, no redirection**
```
$ python3 -m cProfile -s time ./googler hello -c in --noprompt
...
         88228 function calls (86860 primitive calls) in 0.896 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       22    0.469    0.021    0.469    0.021 {method 'read' of '_ssl._SSLSocket' objects}
        1    0.103    0.103    0.103    0.103 {method 'do_handshake' of '_ssl._SSLSocket' objects}
        1    0.075    0.075    0.076    0.076 {built-in method _socket.getaddrinfo}
        1    0.042    0.042    0.042    0.042 {method 'connect' of '_socket.socket' objects}
        3    0.024    0.008    0.024    0.008 {built-in method _imp.create_dynamic}
        4    0.021    0.005    0.021    0.005 {built-in method builtins.compile}
     4717    0.013    0.000    0.013    0.000 {method 'match' of '_sre.SRE_Pattern' objects}
      638    0.012    0.000    0.040    0.000 parser.py:301(parse_starttag)
        1    0.008    0.008    0.069    0.069 parser.py:134(goahead)
       48    0.007    0.000    0.007    0.000 {built-in method marshal.loads}
      638    0.005    0.000    0.009    0.000 googler:729(handler)
  232/230    0.005    0.000    0.013    0.000 {built-in method builtins.__build_class__}
```

**With UA enabled and redirection**
```
$ python3 -m cProfile -s time /usr/local/bin/googler hello --noprompt
...
         119405 function calls (118042 primitive calls) in 1.516 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      107    0.761    0.007    0.761    0.007 {method 'read' of '_ssl._SSLSocket' objects}
        2    0.232    0.116    0.232    0.116 {method 'do_handshake' of '_ssl._SSLSocket' objects}
        2    0.164    0.082    0.166    0.083 {built-in method _socket.getaddrinfo}
        2    0.079    0.039    0.079    0.039 {method 'connect' of '_socket.socket' objects}
        3    0.025    0.008    0.025    0.008 {built-in method _imp.create_dynamic}
        4    0.022    0.006    0.022    0.006 {built-in method builtins.compile}
     8101    0.022    0.000    0.022    0.000 {method 'match' of '_sre.SRE_Pattern' objects}
     1009    0.020    0.000    0.067    0.000 parser.py:301(parse_starttag)
        1    0.013    0.013    0.118    0.118 parser.py:134(goahead)
     1080    0.010    0.000    0.010    0.000 {method 'search' of '_sre.SRE_Pattern' objects}
     1009    0.010    0.000    0.018    0.000 googler:729(handler)
       48    0.007    0.000    0.007    0.000 {built-in method marshal.loads}
      977    0.006    0.000    0.013    0.000 parser.py:386(parse_endtag)
  232/230    0.005    0.000    0.014    0.000 {built-in method builtins.__build_class__}
       48    0.005    0.000    0.005    0.000 {method 'decompress' of 'zlib.Decompress' objects}
     4094    0.005    0.000    0.008    0.000 _markupbase.py:48(updatepos)
     62/1    0.005    0.000    1.516    1.516 {built-in method builtins.exec}
```

**With UA enabled, no redirection**
```
$ python3 -m cProfile -s time /usr/local/bin/googler -c in hello --noprompt
...
         115558 function calls (114190 primitive calls) in 1.262 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      104    0.766    0.007    0.766    0.007 {method 'read' of '_ssl._SSLSocket' objects}
        1    0.106    0.106    0.106    0.106 {method 'do_handshake' of '_ssl._SSLSocket' objects}
        1    0.082    0.082    0.084    0.084 {built-in method _socket.getaddrinfo}
        1    0.039    0.039    0.039    0.039 {method 'connect' of '_socket.socket' objects}
        3    0.026    0.009    0.026    0.009 {built-in method _imp.create_dynamic}
        4    0.023    0.006    0.023    0.006 {built-in method builtins.compile}
     8120    0.021    0.000    0.021    0.000 {method 'match' of '_sre.SRE_Pattern' objects}
     1012    0.020    0.000    0.062    0.000 parser.py:301(parse_starttag)
        1    0.012    0.012    0.111    0.111 parser.py:134(goahead)
     1077    0.010    0.000    0.010    0.000 {method 'search' of '_sre.SRE_Pattern' objects}
     1012    0.008    0.000    0.014    0.000 googler:729(handler)
       48    0.007    0.000    0.007    0.000 {built-in method marshal.loads}
      980    0.006    0.000    0.013    0.000 parser.py:386(parse_endtag)
  232/230    0.005    0.000    0.014    0.000 {built-in method builtins.__build_class__}
     4106    0.005    0.000    0.008    0.000 _markupbase.py:48(updatepos)
     62/1    0.005    0.000    1.263    1.263 {built-in method builtins.exec}
```