### PR TITLE
Zsh completion: Do not mark --colors and --nocolor as mutually exclusive

### DIFF
--- a/auto-completion/zsh/_googler
+++ b/auto-completion/zsh/_googler
@@ -11,8 +11,8 @@ local -a args
 args=(
     '(- : *)'{-h,--help}'[show help text and exit]'
     '(-c --tld)'{-c,--tld}'[country-specific search with top-level domain]:top level domain without dot'
-    '(-C --nocolor --colors)'{-C,--nocolor}'[disable color output]'
-    '(-C --nocolor)--colors[set output colors]:six-letter string'
+    '(-C --nocolor)'{-C,--nocolor}'[disable color output]'
+    '(--colors)--colors[set output colors]:six-letter string'
     '(-d --debug)'{-d,--debug}'[enable debugging]'
     '(-j --first --lucky)'{-j,--first,--lucky}'[open the first result in a web browser]'
     '(--json --np --noprompt)--json[output in JSON format; implies --noprompt]'


### PR DESCRIPTION
`--colors` is often used in aliases and `--nocolor` is supposed to be an override option most of the time, so marking them mutually exclusive only makes it hard to override.