### PR TITLE
googler: Remove from __future__ import print_function

### DIFF
--- a/googler
+++ b/googler
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
 import argparse
 import atexit
 import collections


### PR DESCRIPTION
Apparently we forgot to remove the future import when dumping Python 2.7.