### PR TITLE
Remove Linuxbrew from installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Shell completion scripts for Bash, Fish and Zsh can be found in respective subdi
 
 - [AUR](https://aur.archlinux.org/packages/googler/) for Arch Linux;
 - [Fossies](http://fossies.org/linux/googler);
-- [Homebrew](http://braumeister.org/formula/googler) for OS X;
+- [Homebrew](http://braumeister.org/formula/googler) for OS X / macOS;
 - [Debian Sid](https://packages.debian.org/unstable/main/googler).
 
 ### Debian package

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Shell completion scripts for Bash, Fish and Zsh can be found in respective subdi
 
 - [AUR](https://aur.archlinux.org/packages/googler/) for Arch Linux;
 - [Fossies](http://fossies.org/linux/googler);
-- [Homebrew](http://braumeister.org/formula/googler) for OS X, or its Linux fork, [Linuxbrew](https://github.com/Linuxbrew/homebrew-core/blob/master/Formula/googler.rb);
+- [Homebrew](http://braumeister.org/formula/googler) for OS X;
 - [Debian Sid](https://packages.debian.org/unstable/main/googler).
 
 ### Debian package


### PR DESCRIPTION
Your call, but I'm not a big fan of Linuxbrew these days because it is regularly outdated — remember the Linuxbrew version of googler stuck on 2.3 in mid July (#120)? I still use it for many things, but for our lightweight project with no deps, there are much better options like downloading the script directly and letting it update itself.

While we're at it, I'm updating the OS X moniker per Apple's rebranding.