### PR TITLE
googler: Allow browser output in certain cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 [![Donate Button](https://img.shields.io/badge/paypal-donate-orange.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RMLTQ76JSXJ4Q)
 
-# Table of contents
+## Table of contents
 
 - [Features](#features)
 - [Installation](#installation)
@@ -43,7 +43,7 @@
 - [Developers](#developers)
 - [Notes](#notes)
 
-# Features
+## Features
 
 - Google Search, Google Site Search, Google News
 - Fast and clean (no ads, stray URLs or clutter), custom color
@@ -59,11 +59,11 @@
 - Man page with examples, shell completion scripts for Bash, Zsh and Fish
 - Minimal dependencies
 
-# Installation
+## Installation
 
 `googler` requires Python 3.3 or later. Only the latest patch release of each minor version is supported.
 
-## Installing from this repository
+### Installing from this repository
 
 To download this repository, you may either clone via git:
 
@@ -71,7 +71,7 @@ To download this repository, you may either clone via git:
 
 or download a source code archive: [the latest stable release](https://github.com/jarun/googler/releases/latest) or [the development version](https://github.com/jarun/googler/archive/master.zip).
 
-### Installing to default or custom location
+#### Installing to default or custom location
 
 To install to the default location (`/usr/local`):
 
@@ -83,17 +83,17 @@ To remove `googler` and associated docs, run
 
 `PREFIX` is supported, in case you want to install to a different location.
 
-### Running as a standalone utility
+#### Running as a standalone utility
 
 `googler` is a standalone executable. From the containing directory:
 
     $ ./googler
 
-### Shell completion
+#### Shell completion
 
 Shell completion scripts for Bash, Fish and Zsh can be found in respective subdirectories of [`auto-completion/`](auto-completion). Please refer to your shell's manual for installation instructions.
 
-## Installing with a package manager
+### Installing with a package manager
 
 `googler` is also available on
 
@@ -102,7 +102,7 @@ Shell completion scripts for Bash, Fish and Zsh can be found in respective subdi
 - [Homebrew](http://braumeister.org/formula/googler) for OS X / macOS;
 - [Debian Sid](https://packages.debian.org/unstable/main/googler).
 
-### Debian package
+#### Debian package
 
 If you are on a Debian based system (including Ubuntu), visit [the latest stable release](https://github.com/jarun/googler/releases/latest) and download the`.deb` package. To install, run
 
@@ -110,7 +110,7 @@ If you are on a Debian based system (including Ubuntu), visit [the latest stable
 
 Please substitute `$version` with the appropriate package version.
 
-### Tips for packagers
+#### Tips for packagers
 
 `googler` v2.7 and later ships with an in-place self-upgrade mechanism which you may want to disable. To do this, run
 
@@ -118,7 +118,7 @@ Please substitute `$version` with the appropriate package version.
 
 before installation.
 
-## Downloading a single file
+### Downloading a single file
 
 Googler is a single standalone script, so you could download just a single file if you'd like to.
 
@@ -138,9 +138,9 @@ and upgrade by running
 
     $ sudo googler -U --include-git
 
-# Usage
+## Usage
 
-## Cmdline options
+### Cmdline options
 
     usage: googler [-h] [-s N] [-n N] [-N] [-c TLD] [-l LANG] [-x] [-C]
                    [--colors COLORS] [-j] [-t dN] [-w SITE] [-p PROXY] [--json] [--noua]
@@ -191,7 +191,7 @@ and upgrade by running
       ?                     show omniprompt help
       *                     any other string initiates a new search with original options
 
-## Configuration file
+### Configuration file
 
 `googler` doesn't have any! This is to retain the speed of the utility and avoid OS-specific differences. Users can enjoy the advantages of config files using aliases (with the exception of the color scheme, which can be additionally customized through an environment variable; see [Colors](#colors)). There's no need to memorize options.
 
@@ -206,7 +206,7 @@ The alias serves both the purposes of using config files:
 - Persistent settings: when the user invokes `g`, it expands to the preferred settings.
 - Override settings: thanks to the way Python `argparse` works, `googler` is written so that the settings in alias are completely overridden by any options passed from cli. So when the same user runs `g -l de -c de -n 12 hello world`, 12 results are returned from the Google Germany server, with preference towards results in German.
 
-## Colors
+### Colors
 
 `googler` allows you to customize the color scheme via a six-letter string, reminiscent of BSD `LSCOLORS`. The six letters represent the colors of
 
@@ -263,7 +263,7 @@ Note that
 
 Please consult the manual of your terminal emulator as well as the [Wikipedia article](https://en.wikipedia.org/wiki/ANSI_escape_code) on ANSI escape sequences.
 
-# Examples
+## Examples
 
 1. Google **hello world**:
 
@@ -335,11 +335,11 @@ Site specific search continues at omniprompt. Use the `g` key to run a regular G
         $ googler -h
         $ man googler
 
-# Troubleshooting
+## Troubleshooting
 
 1. In some instances `googler` may show fewer number of results than you expect, e.g., if you fetch a single result (`-n 1`) it may not show any results. The reason is Google shows some Google service (e.g. Youtube) results, map locations etc. depending on your geographical data, which `googler` tries to omit. In some cases Google (the web-service) doesn't show exactly 10 results (default) on a search. We chose to omit these results as far as possible. While this can be fixed, it would need more processing (and more time). You can just navigate forward to fetch the next set of results.
 
-# Developers
+## Developers
 
 1. Copyright (C) 2008 Henri Hakkinen
 2. Copyright (C) 2015-2016 [Arun Prakash Jana](mailto:engineerarun@gmail.com)
@@ -347,7 +347,7 @@ Site specific search continues at omniprompt. Use the `g` key to run a regular G
 
 Special thanks to [jeremija](https://github.com/jeremija), [shaggytwodope](https://github.com/shaggytwodope) and [Narrat](https://github.com/Narrat) for their contributions and efforts in spreading `googler`.
 
-# Notes
+## Notes
 
 1. Initially I raised a pull request but I could see that the last change was made 7 years earlier. In addition, there is no GitHub activity from the original author [Henri Hakkinen](https://github.com/henux) in past year. I have created this independent repo for the project with the name `googler`. I retained the original copyright information.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
     - [Configuration file](#configuration-file)
     - [Colors](#colors)
 - [Examples](#examples)
+- [FAQ](#faq)
 - [Troubleshooting](#troubleshooting)
 - [Developers](#developers)
 - [Notes](#notes)
@@ -143,8 +144,9 @@ and upgrade by running
 ### Cmdline options
 
     usage: googler [-h] [-s N] [-n N] [-N] [-c TLD] [-l LANG] [-x] [-C]
-                   [--colors COLORS] [-j] [-t dN] [-w SITE] [-p PROXY] [--json] [--noua]
-                   [--np] [-d]
+                   [--colors COLORS] [-j] [-t dN] [-w SITE] [-p PROXY] [--noua]
+                   [--json] [--enable-browser-output] [--np] [-d] [-U]
+                   [--include-git]
                    [KEYWORD [KEYWORD ...]]
 
     Google from the command-line.
@@ -173,6 +175,8 @@ and upgrade by running
                             tunnel traffic through an HTTPS proxy (HOST:PORT)
       --noua                disable user agent
       --json                output in JSON format; implies --noprompt
+      --enable-browser-output
+                            do not suppress browser output (stdin and stdout)
       --np, --noprompt      perform search and exit, do not prompt for further
                             interactions
       -d, --debug           enable debugging
@@ -334,6 +338,20 @@ Site specific search continues at omniprompt. Use the `g` key to run a regular G
 
         $ googler -h
         $ man googler
+
+## FAQ
+
+1. **How do I integrate `googler` with a text-based browser, e.g., `w3m`?**
+
+   Set the `BROWSER` environment variable, for instance,
+
+        $ export BROWSER=w3m
+
+   or for one-time use,
+
+        $ BROWSER=w3m googler query
+
+   Note that due to certain graphical browsers spewing messages to the console, `googler` suppresses browser output by default unless `BROWSER` is set to one of the known text-based browsers: currently `elinks`, `links`, `lynx` or `w3m`. If you use a different text-based browser, you will need to explicitly enable browser output with the `--enable-browser-output` option. In that case, please submit an issue or pull request if you believe your browser is popular enough, and we will consider whitelisting it. See the man page for more details about `--enable-browser-output`.
 
 ## Troubleshooting
 

--- a/auto-completion/bash/googler-completion.bash
+++ b/auto-completion/bash/googler-completion.bash
@@ -12,7 +12,7 @@ _googler () {
     local -a opts opts_with_args
     opts=(-c --tld -C --nocolor -d --debug -h --help --include-git -j --first --lucky --json
           -l --lang -n --count -N --news --noua --np --noprompt -p --proxy -s --start -t --time
-          -U --upgrade --update -w --site -x --exact)
+          -U --upgrade --update -w --site -x --exact --enable-browser-output)
     opts_with_arg=(-c --tld --colors -l --lang -n --count -p --proxy -s --start -t --time -w --site)
 
     # Do not complete non option names

--- a/auto-completion/fish/googler.fish
+++ b/auto-completion/fish/googler.fish
@@ -21,5 +21,6 @@ complete -c googler -s w -l site   -r         --description 'search a site using
 complete -c googler -s d -l debug             --description 'enable debugging'
 complete -c googler -l np -l noprompt         --description 'perform search and exit'
 complete -c googler -l json                   --description 'output in JSON format'
+complete -c googler -l enable-browser-output  --description 'do not suppress browser output'
 complete -c googler -s U -l upgrade -l update --description 'perform in-place self-upgrade'
 complete -c googler -l include-git            --description 'use git master for --upgrade'

--- a/auto-completion/zsh/_googler
+++ b/auto-completion/zsh/_googler
@@ -14,6 +14,7 @@ args=(
     '(-C --nocolor)'{-C,--nocolor}'[disable color output]'
     '(--colors)--colors[set output colors]:six-letter string'
     '(-d --debug)'{-d,--debug}'[enable debugging]'
+    '(--enable-browser-output)--enable-browser-output[do not suppress browser output]'
     '(--include-git)--include-git[when used in conjuction with --upgrade, upgrade to git master]'
     '(-j --first --lucky)'{-j,--first,--lucky}'[open the first result in a web browser]'
     '(--json --np --noprompt)--json[output in JSON format; implies --noprompt]'

--- a/googler
+++ b/googler
@@ -91,22 +91,34 @@ RAW_DOWNLOAD_REPO_BASE = 'https://raw.githubusercontent.com/jarun/googler'
 # Global helper functions
 
 def open_url(url):
-    """Open an URL in the user's default web browser."""
+    """Open an URL in the user's default web browser.
+
+    Whether the browser's output (both stdin and stdout) are suppressed
+    depends on the boolean attribute ``open_url.suppress_browser_output``.
+    If the attribute is not set upon a call, set it to a default value,
+    which means False if BROWSER is set to a known text-based browser --
+    elinks, links, lynx or w3m; or True otherwise.
+    """
+    if not hasattr(open_url, 'suppress_browser_output'):
+        open_url.suppress_browser_output = (os.getenv('BROWSER') not in
+                                            ['elinks', 'links', 'lynx', 'w3m'])
     logger.debug('Opening %s', url)
-    _stderr = os.dup(2)
-    os.close(2)
-    _stdout = os.dup(1)
-    os.close(1)
-    fd = os.open(os.devnull, os.O_RDWR)
-    os.dup2(fd, 2)
-    os.dup2(fd, 1)
+    if open_url.suppress_browser_output:
+        _stderr = os.dup(2)
+        os.close(2)
+        _stdout = os.dup(1)
+        os.close(1)
+        fd = os.open(os.devnull, os.O_RDWR)
+        os.dup2(fd, 2)
+        os.dup2(fd, 1)
     try:
         import webbrowser
         webbrowser.open(url)
     finally:
-        os.close(fd)
-        os.dup2(_stderr, 2)
-        os.dup2(_stdout, 1)
+        if open_url.suppress_browser_output:
+            os.close(fd)
+            os.dup2(_stderr, 2)
+            os.dup2(_stdout, 1)
 
 
 def printerr(msg):
@@ -2066,6 +2078,8 @@ def parse_args(args=None, namespace=None):
            help='disable user agent')
     addarg('--json', dest='json', action='store_true',
            help='output in JSON format; implies --noprompt')
+    addarg('--enable-browser-output', dest='enable_browser_output', action='store_true',
+           help='do not suppress browser output (stdin and stdout)')
     addarg('--np', '--noprompt', dest='noninteractive', action='store_true',
            help='perform search and exit, do not prompt for further interactions')
     addarg('-d', '--debug', dest='debug', action='store_true',
@@ -2105,6 +2119,10 @@ def main():
             colors = None
         Result.colors = colors
         GooglerCmd.colors = colors
+
+        # Handle browser output suppression
+        if opts.enable_browser_output:
+            open_url.suppress_browser_output = False
 
         if opts.noua:
             USER_AGENT = ''

--- a/googler.1
+++ b/googler.1
@@ -53,6 +53,9 @@ Disable user agent. Results are fetched faster. However, abstracts for some Goog
 .BI "--json"
 Output in JSON format; implies \fB--noprompt\fR.
 .TP
+.BI "--enable-browser-output"
+Do not suppress browser output when opening result in browser; that is, connect stdout and stderr of the browser to googler's stdout and stderr instead of /dev/null. By default, browser output is suppressed (due to certain graphical browsers spewing messages to console) unless the \fBBROWSER\fR environment variable is a known text-based browser: elinks, links, lynx or w3m.
+.TP
 .BI "--np, --noprompt"
 Perform search and exit; do not prompt for further interactions.
 .TP


### PR DESCRIPTION
Cases:

- `BROWSER` is one of the known text-based browsers: currently `elinks`, `links`, `lynx` and `w3m`.

- User explicitly passes the `--enable-browser-output` option.

Fixes #125.

## Note

This is a preview, not to be merged yet. Code is done, but I still need to do docs and shell completion. I'll finish the docs later today when I have time.