### PR TITLE
googler: Set process title to googler if setproctitle is installed

### DIFF
--- a/googler
+++ b/googler
@@ -45,6 +45,12 @@ except ImportError:
 
 # Basic setup
 
+try:
+    import setproctitle
+    setproctitle.setproctitle('googler')
+except Exception:
+    pass
+
 logging.basicConfig(format='[%(levelname)s] %(message)s')
 logger = logging.getLogger()
 


### PR DESCRIPTION
Just like what the title says: set process title to `googler` if `setproctitle` is installed.

`setproctitle` is from https://github.com/dvarrazzo/py-setproctitle.

I'm not sure if this is a feature you may want, but to me it's a nice little touch. The googler process will be easier to grep, for instance. This doesn't even have to be mentioned anywhere (well, it might deserve a place in the release notes for a slow news release) since we strive to have no deps. People who happen to have `setproctitle` installed will get this as a Easter egg type feature, and to me it's fair.