### PR TITLE
Makefile: disable-self-upgrade: Use -i.bak instead of -i for sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ uninstall:
 # We assume that sed(1) has the -i option, which is not POSIX but seems common
 # enough in modern implementations.
 disable-self-upgrade:
-	sed -i 's/^ENABLE_SELF_UPGRADE_MECHANISM=True$$/ENABLE_SELF_UPGRADE_MECHANISM=False/' googler
+	sed -i.bak 's/^ENABLE_SELF_UPGRADE_MECHANISM=True$$/ENABLE_SELF_UPGRADE_MECHANISM=False/' googler


### PR DESCRIPTION
Unfortunately, there's a subtle difference between the -i option of GNU and BSD sed: GNU sed interprets `-i` as `-i''` (no backup), while BSD sed picks up the next argument as the backup extension. We have to offer a backup extension in place for the option to be recognized unambiguously by both GNU and BSD sed.