### PR TITLE
README.md: Update Asciinema screencast

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-<a href="https://asciinema.org/a/46340"><img src="https://asciinema.org/a/46340.png" alt="Asciicast" width="734"/></a>
+<a href="https://asciinema.org/a/85019"><img src="https://asciinema.org/a/85019.png" alt="Asciicast" width="734"/></a>
 </p>
 
 `googler` is a power tool to Google (Web & News) and Google Site Search from the command-line. It shows the title, URL and abstract for each result, which can be directly opened in a browser from the terminal. Results are fetched in pages (with page navigation). Supports sequential searches in a single `googler` instance.


### PR DESCRIPTION
Got a new screencast for ya. For the record, the terminal size is 100x49.

- Now using `w3m` as `BROWSER` to avoid the awkwardness of nothing happening after entering an index;
- Self-upgrade mechanism demo at the end.