### PR TITLE
Honoring the environment variable https_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ Site specific search continues at omniprompt. Use the `g` key to run a regular G
 
         $ googler --proxy localhost:8118 google
 
+    The proxy can also be set by the environment variable `https_proxy`.
+
 16. More **help**:
 
         $ googler -h

--- a/googler
+++ b/googler
@@ -2137,6 +2137,12 @@ def main():
         if opts.noua:
             USER_AGENT = ''
 
+        # Handle proxy environment variable
+        if 'https_proxy' in os.environ:
+            logger.debug("Proxy is set via environment variable")
+            proxy_parser = urllib.parse.urlparse(os.environ['https_proxy'])
+            opts.proxy = proxy_parser.netloc
+
         repl = GooglerCmd(opts)
 
         if opts.json or opts.lucky or opts.noninteractive:

--- a/googler.1
+++ b/googler.1
@@ -313,6 +313,8 @@ Tunnel traffic through an \fBHTTPS proxy\fR, e.g., a local Privoxy instance list
 .B googler --proxy localhost:8118 google
 .EE
 .PP
+.IP "" 4
+The proxy can also be set by the environment variable \fIhttps_proxy\fR.
 .SH AUTHORS
 Henri Hakkinen
 .br


### PR DESCRIPTION
If set the environment variable https_proxy is extracted and set as
opts.proxy