### PR TITLE
Properly support https_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,8 +337,6 @@ Site specific search continues at omniprompt. Use the `g` key to run a regular G
 
         $ googler --proxy localhost:8118 google
 
-    The proxy can also be set by the environment variable `https_proxy`.
-
 16. More **help**:
 
         $ googler -h

--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ Site specific search continues at omniprompt. Use the `g` key to run a regular G
 
         $ googler --proxy localhost:8118 google
 
+    The proxy can also be set by the environment variable `https_proxy`.
+
 16. More **help**:
 
         $ googler -h

--- a/googler
+++ b/googler
@@ -2137,12 +2137,6 @@ def main():
         if opts.noua:
             USER_AGENT = ''
 
-        # Handle proxy environment variable
-        if 'https_proxy' in os.environ:
-            logger.debug("Proxy is set via environment variable")
-            proxy_parser = urllib.parse.urlparse(os.environ['https_proxy'])
-            opts.proxy = proxy_parser.netloc
-
         repl = GooglerCmd(opts)
 
         if opts.json or opts.lucky or opts.noninteractive:

--- a/googler
+++ b/googler
@@ -2032,6 +2032,19 @@ def self_upgrade(include_git=False):
 
 # Miscellaneous functions
 
+def https_proxy_from_environment():
+    if 'https_proxy' not in os.environ:
+        return None
+    proxy = urllib.parse.urlparse(os.environ['https_proxy']).netloc
+    # urlparse recognizes a netloc only if it is introduced by '//'
+    # (https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse).
+    # This means a bare host:port like 'localhost:8118' won't be
+    # recognized. In that case, try again with the '//' prefix.
+    if not proxy:
+        proxy = urllib.parse.urlparse('//' + os.environ['https_proxy']).netloc
+    return proxy if proxy else None
+
+
 def parse_args(args=None, namespace=None):
     """Parse googler arguments/options.
 
@@ -2080,7 +2093,7 @@ def parse_args(args=None, namespace=None):
            '[h5 (5 hrs), d5 (5 days), w5 (5 weeks), m5 (5 months), y5 (5 years)]')
     addarg('-w', '--site', dest='site', metavar='SITE',
            help='search a site using Google')
-    addarg('-p', '--proxy', dest='proxy',
+    addarg('-p', '--proxy', dest='proxy', default=https_proxy_from_environment(),
            help='tunnel traffic through an HTTPS proxy (HOST:PORT)')
     addarg('--noua', dest='noua', action='store_true',
            help='disable user agent')

--- a/googler.1
+++ b/googler.1
@@ -45,7 +45,7 @@ Time limit search [h5 (5 hrs), d5 (5 days), w5 (5 weeks), m5 (5 months), y5 (5 y
 Search a site using Google.
 .TP
 .BI "-p, --proxy=" PROXY
-Tunnel traffic through an HTTPS proxy. \fIPROXY\fR is of the form \fIHOST:PORT\fR. The proxy server must support HTTP CONNECT tunneling and must not block port 443 for the relevant Google hosts.
+Tunnel traffic through an HTTPS proxy. \fIPROXY\fR is of the form \fIHOST:PORT\fR. The proxy server must support HTTP CONNECT tunneling and must not block port 443 for the relevant Google hosts. If a proxy is not explicitly given, the \fIhttps_proxy\fR environment variable (if available) is used instead.
 .TP
 .BI "--noua"
 Disable user agent. Results are fetched faster. However, abstracts for some Google service (e.g. YouTube, Google Books) results don't show.
@@ -179,6 +179,9 @@ Overrides the default browser. Ref:
 .TP
 .BI GOOGLER_COLORS
 Refer to the \fBCOLORS\fR section.
+.TP
+.BI https_proxy
+Refer to the \fB--proxy\fR option.
 .SH EXAMPLES
 .PP
 .IP 1. 4


### PR DESCRIPTION
Correct a few mistakes/oversights in #140:

- Env var overriding command line argument;
- Bare host:port (like localhost:8118) isn't parsed properly;
- In the man page, `https_proxy` is documented anywhere "formal" (EXAMPLES is an optional section).