### PR TITLE
googler: remove the logging.shutdown exit handler

### DIFF
--- a/googler
+++ b/googler
@@ -2177,4 +2177,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-    atexit.register(logging.shutdown)


### PR DESCRIPTION
Introduced in dfd3d5c. However,

1. The handler is registered at the wrong place.
2. We are logging with the standard stream handler to `sys.stderr`. `logging.shutdown` is useless in this case, because `sys.stderr` is automatically flushed and closed at exit (and `logging.shutdown` won't be able to close it anyway).

If you want to keep the `logging.shutdown` exit handler, it should be lifted, probably into the following group of global statements:

```py
# Set up logging
logging.basicConfig(format='[%(levelname)s] %(message)s')
logger = logging.getLogger()
```

or at least before the earliest point of exit.