### PR TITLE
googler: fix tunneling in TLS1_2Connection

### DIFF
--- a/googler
+++ b/googler
@@ -158,7 +158,6 @@ class TLS1_2Connection(HTTPSConnection):
 
         if getattr(self, '_tunnel_host', None):
             self.sock = sock
-            self._tunnel()
             HTTPSConnection.connect(self)
         elif not notweak and sys.version_info >= (3,4):
             # Use TLS 1.2


### PR DESCRIPTION
`HTTPSConnection.connect` calls `self._tunnel` already when `self._tunnel_host` is set. (CPython 3.3.6, 3.4.5, 3.5.2, 3.6.0b4.) Ref: https://github.com/python/cpython/blob/3.3/Lib/http/client.py#L819-L824.

Fixes #146.

A quick comparison of `http/client.py` between the Py33 and Py34 branches doesn't tell me why the problem isn't seen on 3.4, though.

I still have reservations about using internals, but this is the quickest fix, for a code path that I don't care much about 😜.