### PR TITLE
googler: revamp TLS 1.2 support

### DIFF
--- a/googler
+++ b/googler
@@ -158,13 +158,23 @@ class TLS1_2Connection(HTTPSConnection):
 
         if getattr(self, '_tunnel_host', None):
             self.sock = sock
-            HTTPSConnection.connect(self)
-        elif not notweak and sys.version_info >= (3,4):
-            # Use TLS 1.2
-            self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
-                    ssl_version=ssl.PROTOCOL_TLSv1_2)
-        else:
-            HTTPSConnection.connect(self)
+        elif not notweak:
+            # Try to use TLS 1.2
+            ssl_context = None
+            if hasattr(ssl, 'PROTOCOL_TLS'):
+                # Since Python 3.5.3
+                ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+                ssl_context.options |= (ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 |
+                                        ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1)
+            elif hasattr(ssl, 'PROTOCOL_TLSv1_2'):
+                # Since Python 3.4
+                ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+            if ssl_context:
+                self.sock = ssl_context.wrap_socket(sock)
+                return
+
+        # Fallback
+        HTTPSConnection.connect(self)
 
 class GoogleUrl(object):
     """


### PR DESCRIPTION
OpenSSL has deprecated all version specific protocols. As such, version
specific protocols including PROTOCOL_TLSv1_2 have been deprecated in
Python since 3.5.3. PROTOCOL_TLS coupled with SSLContext options to
disable older protocol versions is the new way to go. See
https://docs.python.org/3.5/library/ssl.html#ssl.PROTOCOL_TLSv1_2 and
https://docs.python.org/3.5/library/ssl.html#protocol-versions.

We are now using feature test (hasattr) instead of version test which is
generally preferred.

Also, key_file and cert_file code has been removed since they're None
anyway (they are only set when key_file and cert_file are passed to
HTTPSConnection, something we don't have).