### PR TITLE
.travis.yml: add 3.6-dev to the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6-dev"
 addons:
   apt:
     packages:


### PR DESCRIPTION
Python 3.6 is less than one month from release. Time to add 3.6 to the matrix.