### PR TITLE
Make sure stdout encoding is UTF-8

### DIFF
--- a/googler
+++ b/googler
@@ -20,21 +20,23 @@
 import argparse
 import atexit
 import collections
+import codecs
 import functools
 import gzip
 import html.entities
 import html.parser
 import http.client
 from http.client import HTTPSConnection
-import webbrowser
-import socket
-import ssl
+import locale
 import logging
 import os
 import signal
+import socket
+import ssl
 import sys
 import textwrap
 import urllib.parse
+import webbrowser
 
 # Python optional dependency compatibility layer
 try:
@@ -132,6 +134,62 @@ def printerr(msg):
     ``msg`` could be any stringifiable value.
     """
     print(msg, file=sys.stderr)
+
+
+def unwrap(text):
+    """Unwrap text."""
+    lines = text.split('\n')
+    result = ''
+    for i in range(len(lines) - 1):
+        result += lines[i]
+        if not lines[i]:
+            # Paragraph break
+            result += '\n\n'
+        elif lines[i + 1]:
+            # Next line is not paragraph break, add space
+            result +=  ' '
+    # Handle last line
+    result += lines[-1] if lines[-1] else '\n'
+    return result
+
+
+def check_stdout_encoding():
+    """Make sure stdout encoding is utf-8.
+
+    If not, print error message and intrustructions, then exit with
+    status 1.
+
+    This function is a no-op on win32 because encoding on win32 is
+    messy, and let's just hope for the best. /s
+    """
+    if sys.platform == 'win32':
+        return
+
+    # Use codecs.lookup to resolve text encoding alias
+    encoding = codecs.lookup(sys.stdout.encoding).name
+    if encoding != 'utf-8':
+        locale_lang, locale_encoding = locale.getlocale()
+        if locale_lang is None:
+            locale_lang = '<unknown>'
+        if locale_encoding is None:
+            locale_encoding = '<unknown>'
+        ioencoding = os.getenv('PYTHONIOENCODING', 'not set')
+        sys.stderr.write(unwrap(textwrap.dedent("""\
+        stdout encoding '{encoding}' detected. googler requires utf-8 to
+        work properly. The wrong encoding may be due to a non-UTF-8
+        locale or an improper PYTHONIOENCODING. (For the record, your
+        locale language is {locale_lang} and locale encoding is
+        {locale_encoding}; your PYTHONIOENCODING is {ioencoding}.)
+
+        Please set a UTF-8 locale (e.g., en_US.UTF-8) or set
+        PYTHONIOENCODING to utf-8.
+        """.format(
+            encoding=encoding,
+            locale_lang=locale_lang,
+            locale_encoding=locale_encoding,
+            ioencoding=ioencoding,
+        ))))
+        sys.exit(1)
 
 
 # Classes
@@ -2147,6 +2205,8 @@ def main():
         if hasattr(opts, 'upgrade') and opts.upgrade:
             self_upgrade(include_git=opts.include_git)
             sys.exit(0)
+
+        check_stdout_encoding()
 
         # Set colors
         if opts.colorize:

--- a/googler
+++ b/googler
@@ -31,7 +31,6 @@ import socket
 import ssl
 import logging
 import os
-import platform
 import signal
 import sys
 import textwrap
@@ -151,7 +150,7 @@ class TLS1_2Connection(HTTPSConnection):
                 self.timeout, self.source_address)
 
         # Optimizations not available on OS X
-        if not notweak and platform.system() == 'Linux':
+        if not notweak and sys.platform.startswith('linux'):
             sock.setsockopt(socket.SOL_TCP, socket.TCP_DEFER_ACCEPT, 1)
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_QUICKACK, 1)
             sock.setsockopt(socket.SOL_SOCKET,socket.SO_RCVBUF,524288)


### PR DESCRIPTION
Python 3 is much better at defaulting to UTF-8, the one true encoding, but unfortunately you can still have non-UTF-8 stdout:[1]

> The character encoding is platform-dependent. Under Windows, if the stream is interactive (that is, if its isatty() method returns True), the console codepage is used, otherwise the ANSI code page. Under other platforms, the locale encoding is used (see locale.getpreferredencoding()).
>
> Under all platforms though, you can override this value by setting the PYTHONIOENCODING environment variable before starting Python.

`PYTHONIOENCODING` would solve it once and for all, but again unfortunately, a shebang like

```sh
#!/usr/bin/env PYTHONIOENCODING=utf-8 python3
```

isn't cross platform; and googler, proud of being a single-script program, can't afford a wrapper script. (In fact, we can totally explore that option for a Makefile based install.) Alternatively we could

1. Force the encoding post Python init;
2. Print encoded 8-bit data directly to the underlying binary buffers.

The former (when implemented through `codecs.StreamWriter`) has shown to interact poorly with readline; the latter is plain ugly.

That leaves us with one option (other than the wrapper script, which I'll explore in a separate PR): ask users to do the right thing.

In this PR, we check to make sure stdout encoding is `utf-8` (post argparse, so the check isn't performed if we're only printing help message), and abort if not. The message should be fairly helpful, complete with what users are expected to do (but I won't try to teach users how to set environment variables):

```
$ unset LC_ALL PYTHONIOENCODING
$ LC_CTYPE=en_US.US-ASCII googler hello
stdout encoding 'ascii' detected. googler requires utf-8 to work properly. The wrong encoding may be due to a non-UTF-8 locale or an improper PYTHONIOENCODING. (For the record, your locale language is en_US and locale encoding is ISO8859-1; your PYTHONIOENCODING is not set.)

Please set a UTF-8 locale (e.g., en_US.UTF-8) or set PYTHONIOENCODING to utf-8.
$ LC_CTYPE=en_US.ISO8859-1 googler hello
stdout encoding 'iso8859-1' detected. googler requires utf-8 to work properly. The wrong encoding may be due to a non-UTF-8 locale or an improper PYTHONIOENCODING. (For the record, your locale language is en_US and locale encoding is ISO8859-1; your PYTHONIOENCODING is not set.)

Please set a UTF-8 locale (e.g., en_US.UTF-8) or set PYTHONIOENCODING to utf-8.
$ LC_CTYPE=zh_CN.GBK googler hello
stdout encoding 'gbk' detected. googler requires utf-8 to work properly. The wrong encoding may be due to a non-UTF-8 locale or an improper PYTHONIOENCODING. (For the record, your locale language is zh_CN and locale encoding is gbk; your PYTHONIOENCODING is not set.)

Please set a UTF-8 locale (e.g., en_US.UTF-8) or set PYTHONIOENCODING to utf-8.
$ LC_CTYPE=zh_TW.Big5 googler hello
stdout encoding 'big5' detected. googler requires utf-8 to work properly. The wrong encoding may be due to a non-UTF-8 locale or an improper PYTHONIOENCODING. (For the record, your locale language is zh_TW and locale encoding is big5; your PYTHONIOENCODING is not set.)

Please set a UTF-8 locale (e.g., en_US.UTF-8) or set PYTHONIOENCODING to utf-8.
$ PYTHONIOENCODING=utf-16 googler hello
stdout encoding 'utf-16' detected. googler requires utf-8 to work properly. The wrong encoding may be due to a non-UTF-8 locale or an improper PYTHONIOENCODING. (For the record, your locale language is en_US and locale encoding is UTF-8; your PYTHONIOENCODING is utf-16.)

Please set a UTF-8 locale (e.g., en_US.UTF-8) or set PYTHONIOENCODING to utf-8.
```

This is a rather heavy-handed approach, but frankly I think it's much better than failing with a cryptic `UnicodeEncodeError`, which users then need to search about. (By the way, I tried a bunch of simple English words in US Google, and the results always contain non-ASCII characters, so the failure rate when stdout encoding isn't utf-8 is basically 100%.)

I'm not checking on win32 because

1. No one uses googler on win32;
2. I'm too lazy to check whether to expect `utf-8` or `cp65001`.

There's also a drive-by commit to eliminate the need of the `platform` module (in favor of consistent use of `sys.platform`).

[1] https://docs.python.org/3/library/sys.html#sys.stdout