### PR TITLE
Include commit hash in version number when possible

### DIFF
--- a/googler
+++ b/googler
@@ -99,6 +99,36 @@ RAW_DOWNLOAD_REPO_BASE = 'https://raw.githubusercontent.com/jarun/googler'
 
 # Global helper functions
 
+def _version_():
+    """Returns a version number with git commit embedded if possible.
+
+    Falls back to _VERSION_ otherwise.
+    """
+    import subprocess
+
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    DEVNULL = subprocess.DEVNULL
+
+    try:
+        description = subprocess.check_output(
+            ['git', '-C', script_dir, 'describe', '--abbrev', 'HEAD'],
+            stdin=DEVNULL, stderr=DEVNULL,
+        ).decode('utf-8')
+        return description.lstrip('v')
+    except subprocess.CalledProcessError:
+        pass
+
+    try:
+        sha = subprocess.check_output(
+            ['git', '-C', script_dir, 'rev-parse', '--short', 'HEAD'],
+            stdin=DEVNULL, stderr=DEVNULL,
+        ).decode('utf-8')
+        return '%s-*-g%s' % (_VERSION_, sha)
+    except subprocess.CalledProcessError:
+        pass
+
+    return _VERSION_
+
 def open_url(url):
     """Open an URL in the user's default web browser.
 
@@ -2012,7 +2042,7 @@ class GooglerArgumentParser(argparse.ArgumentParser):
         Zhiming Wang <zmwangx@gmail.com>
         License: GPLv3
         Webpage: https://github.com/jarun/googler
-        """ % _VERSION_))
+        """ % _version_()))
 
     # Augment print_help to print more than synopsis and options
     def print_help(self, file=None):
@@ -2277,7 +2307,7 @@ def parse_args(args=None, namespace=None):
                help='perform in-place self-upgrade')
         addarg('--include-git', action='store_true',
                help='when used with --upgrade, upgrade to latest git master')
-    addarg('-v', '--version', action='version', version=_VERSION_)
+    addarg('-v', '--version', action='version', version=_version_())
     addarg('-d', '--debug', action='store_true', help='enable debugging')
 
     return argparser.parse_args(args, namespace)
@@ -2296,7 +2326,7 @@ def main():
         # Set logging level
         if opts.debug:
             logger.setLevel(logging.DEBUG)
-            logger.debug('Version %s', _VERSION_)
+            logger.debug('Version %s', _version_())
 
         # Handle self-upgrade
         if hasattr(opts, 'upgrade') and opts.upgrade:

--- a/googler
+++ b/googler
@@ -2116,7 +2116,8 @@ def download_latest_googler(include_git=False):
 
     By default, the latest released version is downloaded, but if
     `include_git` is specified, then the latest git master is downloaded
-    instead.
+    instead, and the commit hash is baked into _VERSION_ of the
+    downloaded script.
 
     Parameters
     ----------
@@ -2125,13 +2126,22 @@ def download_latest_googler(include_git=False):
 
     Returns
     -------
-    (git_ref, path): tuple
-         A tuple containing the git reference (either name of the latest
-         tag or SHA of the latest commit) and path to the downloaded
-         file.
+    (version, path): tuple
+         A tuple containing the version number and path to the
+         downloaded file.
 
     """
     import urllib.request
+
+    # Get name of latest tag
+    request = urllib.request.Request('%s/releases?per_page=1' % API_REPO_BASE,
+                                     headers={'Accept': 'application/vnd.github.v3+json'})
+    response = urllib.request.urlopen(request)
+    if response.status != 200:
+        raise http.client.HTTPException(response.reason)
+    import json
+    git_ref = json.loads(response.read().decode('utf-8'))[0]['tag_name']
+    version = git_ref.lstrip('v')
 
     if include_git:
         # Get SHA of latest commit on master
@@ -2141,15 +2151,11 @@ def download_latest_googler(include_git=False):
         if response.status != 200:
             raise http.client.HTTPException(response.reason)
         git_ref = response.read().decode('utf-8')
-    else:
-        # Get name of latest tag
-        request = urllib.request.Request('%s/releases?per_page=1' % API_REPO_BASE,
-                                         headers={'Accept': 'application/vnd.github.v3+json'})
-        response = urllib.request.urlopen(request)
-        if response.status != 200:
-            raise http.client.HTTPException(response.reason)
-        import json
-        git_ref = json.loads(response.read().decode('utf-8'))[0]['tag_name']
+        version += '-*-g%s' % git_ref[:7]
+
+    # Make sure API response is reasonable
+    import re
+    assert re.match(r'^[0-9a-g.*-]+$', version), 'Invalid remote version number "%s"' % version
 
     # Download googler to a tempfile
     googler_download_url = '%s/%s/googler' % (RAW_DOWNLOAD_REPO_BASE, git_ref)
@@ -2169,7 +2175,20 @@ def download_latest_googler(include_git=False):
                 fp.write(gzip.decompress(payload))
             except OSError:
                 fp.write(payload)
-    return git_ref, path
+
+    # Rewrite the value of _VERSION_ with version if downloading git master
+    if include_git:
+        with open(path) as fp:
+            content = fp.read()
+        # This should be safe because we already verified above that
+        # version doesn't contain any surprises, at least not enough to
+        # break out of its jail of single quotes.
+        logger.debug('Rewriting _VERSION_ in downloaded script to %s', version)
+        content = re.sub(r'^_VERSION_ = .*$', "_VERSION_ = '%s'" % version, content, flags=re.M)
+        with open(path, 'w') as fp:
+            fp.write(content)
+
+    return version, path
 
 
 def self_replace(path):
@@ -2224,9 +2243,17 @@ def self_upgrade(include_git=False):
         See `download_latest_googler`. Default is False.
 
     """
-    git_ref, path = download_latest_googler(include_git=include_git)
+    current_version = _version_()
+    printerr('Upgrading from version %s' % current_version)
+    version, path = download_latest_googler(include_git=include_git)
+
+    # Warn if "upgrading" from a git commit to a stable below it
+    if current_version.startswith('%s-' % version):
+        logger.warning('%s => %s may be a downgrade; did you forget --include-git?',
+                       current_version, version)
+
     if self_replace(path):
-        printerr('Upgraded to %s.' % git_ref)
+        printerr('Upgraded to version %s.' % version)
     else:
         printerr('Already up to date.')
 

--- a/googler
+++ b/googler
@@ -2143,13 +2143,13 @@ def download_latest_googler(include_git=False):
         git_ref = response.read().decode('utf-8')
     else:
         # Get name of latest tag
-        request = urllib.request.Request('%s/tags?per_page=1' % API_REPO_BASE,
+        request = urllib.request.Request('%s/releases?per_page=1' % API_REPO_BASE,
                                          headers={'Accept': 'application/vnd.github.v3+json'})
         response = urllib.request.urlopen(request)
         if response.status != 200:
             raise http.client.HTTPException(response.reason)
         import json
-        git_ref = json.loads(response.read().decode('utf-8'))[0]['name']
+        git_ref = json.loads(response.read().decode('utf-8'))[0]['tag_name']
 
     # Download googler to a tempfile
     googler_download_url = '%s/%s/googler' % (RAW_DOWNLOAD_REPO_BASE, git_ref)


### PR DESCRIPTION
- In a git repo (that is, when `googler` — after symlink resolution — is a git repo), use `git-describe` (or `git-rev-parse` as fallback) on HEAD to determine the exact commit. Examples:

  ```
  $ googler --version
  2.9-21-g3f46a90
  ```

  or when the clone is shallow, without tags:

  ```
  $ ./googler --version
  2.9-*-g3f46a90
  ```

  Note that if HEAD is at an exact tag, you won't see that trailing `-<count>-g<sha>` (which is apparently preferable), simply due to how `git describe --abbrev HEAD` works.

- Outside a git repo, if the script is downloaded via `googler --upgrade --include-git`, we now put the commit hash into `_VERSION_`, also in the `<major>.<minor>-*-g<sha>` format seen in the shallow case above (since we can't get commit count since tag/release from GitHub API v3). Sample session:

  ```
  $ ./googler -u --include-git
  Upgrading from version 2.9-*-g3f46a90
  Downloading https://raw.githubusercontent.com/jarun/googler/df256cf083488be6aa9ea4459b624e84802ab0df/googler
  Upgraded to version 2.9-*-gdf256cf.
  ```

  A nice bonus is we can now warn about downgrading from git master to stable (due to missing `--include-git`:

  ```
  $ ./googler -u
  Upgrading from version 2.9-*-g3f46a90
  Downloading https://raw.githubusercontent.com/jarun/googler/v2.9/googler
  [WARNING] 2.9-*-g3f46a90 => 2.9 may be a downgrade; did you forget --include-git?
  Upgraded to version 2.9.
  ```

  To be fair, maybe zero people will benefit from this (I'm afraid at most a handful users use `-u`, less `--include-git`), but IMO it's pretty neat from a design point of view. 💯 