### PR TITLE
Miscellaneous

### DIFF
--- a/googler
+++ b/googler
@@ -292,7 +292,7 @@ class GoogleUrl(object):
         self._num = 10
         self._start = 0
         self._keywords = []
-        self._site = None
+        self._sites = None
         self._query_dict = {
             'ie': 'UTF-8',
             'oe': 'UTF-8',
@@ -418,8 +418,8 @@ class GoogleUrl(object):
                 qd.pop('tbm', None)
         if 'num' in opts:
             self._num = opts['num']
-        if 'site' in opts:
-            self._site = opts['site']
+        if 'sites' in opts:
+            self._sites = opts['sites']
         if 'start' in opts:
             self._start = opts['start']
         if 'tld' in opts:
@@ -581,13 +581,14 @@ class GoogleUrl(object):
         # Construct the q query
         q = ''
         keywords = self._keywords
+        sites = self._sites
         if keywords:
             if isinstance(keywords, list):
                 q += '+'.join([urllib.parse.quote_plus(kw) for kw in keywords])
             else:
                 q += urllib.parse.quote_plus(keywords)
-        if self._site:
-            q += '+OR'.join(['+site:' + urllib.parse.quote_plus(site) for site in self._site])
+        if sites:
+            q += '+OR'.join(['+site:' + urllib.parse.quote_plus(site) for site in sites])
         qd['q'] = q
 
         return '&'.join(['%s=%s' % (k, qd[k]) for k in sorted(qd.keys())])
@@ -2268,7 +2269,7 @@ def parse_args(args=None, namespace=None):
     addarg('-t', '--time', dest='duration', type=argparser.is_duration,
            metavar='dN', help='time limit search '
            '[h5 (5 hrs), d5 (5 days), w5 (5 weeks), m5 (5 months), y5 (5 years)]')
-    addarg('-w', '--site', action='append', metavar='SITE',
+    addarg('-w', '--site', dest='sites', action='append', metavar='SITE',
            help='search a site using Google')
     addarg('-p', '--proxy', default=https_proxy_from_environment(),
            help='tunnel traffic through an HTTPS proxy (HOST:PORT)')

--- a/googler
+++ b/googler
@@ -584,14 +584,14 @@ class GoogleUrl(object):
         sites = self._sites
         if keywords:
             if isinstance(keywords, list):
-                q += '+'.join([urllib.parse.quote_plus(kw) for kw in keywords])
+                q += '+'.join(urllib.parse.quote_plus(kw) for kw in keywords)
             else:
                 q += urllib.parse.quote_plus(keywords)
         if sites:
-            q += '+OR'.join(['+site:' + urllib.parse.quote_plus(site) for site in sites])
+            q += '+OR'.join('+site:' + urllib.parse.quote_plus(site) for site in sites)
         qd['q'] = q
 
-        return '&'.join(['%s=%s' % (k, qd[k]) for k in sorted(qd.keys())])
+        return '&'.join('%s=%s' % (k, qd[k]) for k in sorted(qd.keys()))
 
 
 class GoogleConnectionError(Exception):


### PR DESCRIPTION
By the way, I'm not sure our use of `OR` is well-defined. According to https://support.google.com/websearch/answer/2466433?hl=en:

> Combine searches
> Put "OR" between each search query. For example,  marathon OR race.
>
> Search for a specific site
> Put "site:" in front of a site or domain. For example, site:youtube.com or site:.gov.

It's not entirely clear what consists of a "search query", but in this context I think it means the keywords/keyphrases without qualifiers; at least that's the only safe way to read it. Also, it's not clear which parts of a query are or'ed (that is, where to put parentheses if you were to parse the query), in a query like

    keyword filetype:type site:example.com OR site:example.org OR site:example.net

https://www.google.com/advanced_search also does not provide a way to search multiple sites/domains.

Therefore, my conclusion is we're treading on a less well-defined rule, but it appears to work:

```
$ googler --debug --json -w github.com -w gitlab.com iterm2 | jq -r '.[].url'
[DEBUG] Version 3.0
[DEBUG] Connecting to new host www.google.com
[DEBUG] Fetching URL /search?ie=UTF-8&nfpr=1&num=10&oe=UTF-8&q=iterm2+site:github.com+OR+site:gitlab.com
[DEBUG] Cookie: NID=99=QU3W5DneIxaOl5nxPadSh_GEaBMIZ9DE0-oX6wV2FWAVoih_E5czpZBz992il4BzGzmQ4FcVfoUFwF9xIJsxtZ1miWdNuLimlN7srcaPDQvCPolJjLQX8Xo27LU_ua50jCRPUEjBUxWxKKr6
[DEBUG] Response body written to '/Volumes/ramdisk/googler-response-6_ds7_kl'.
https://github.com/gnachman/iTerm2
https://github.com/altercation/solarized/tree/master/iterm2-colors-solarized
https://github.com/mbadolato/iTerm2-Color-Schemes
https://gist.github.com/kevin-smets/8568070
https://github.com/chriskempson/base16-iterm2
https://github.com/morhetz/gruvbox-contrib/tree/master/iterm2
https://github.com/mhartington/oceanic-next-iterm
https://github.com/mmastrac/iterm2-zmodem
https://gitlab.com/gnachman/iterm2
https://gitlab.com/gnachman/iterm2/issues
```

I was thinking about making it clear in docs that `-w, --site` can be specified multiple times, but given the arguments above, it's probably safer to keep it an undocumented feature. After all, I'm not prepared to spend even more time on a feature that one user has requested over the lifetime of googler.