### PR TITLE
Add docker image to run googler with docker

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+googler 3.1
+Unreleased
+
+Modifications
+- Add `googler` tiny lightweight docker image
+
+-------------------------------------------------------------------------------
+
 googler 3.0
 2017-03-12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3-alpine
+
+RUN apk update && \
+    apk add ca-certificates wget  && \
+    update-ca-certificates
+
+RUN wget https://raw.githubusercontent.com/jarun/googler/v3.0/googler -O /usr/local/bin/googler && \
+    chmod +x /usr/local/bin/googler
+
+ENTRYPOINT ["googler"]

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ To remove `googler` and associated docs, run
 
     $ ./googler
 
+#### Running with Docker
+
+We provide `googler` with a tiny lightweight Docker image derived from python:3-alpine.
+
+In order to build `googler` docker image, run:
+
+    $ docker build -t jarun/googler path/to/Dockerfile
+
+Once the docker image has been built, run the following command to execute `googler`:
+
+    $ docker run -it jarun/googler
+
 #### Shell completion
 
 Shell completion scripts for Bash, Fish and Zsh can be found in respective subdirectories of [`auto-completion/`](auto-completion). Please refer to your shell's manual for installation instructions.


### PR DESCRIPTION
This PR adds a Dockerfile to build tiny lightweight docker image in order to run `googler` with ease.