### PR TITLE
Revert "Make --json imply --exact"

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ and upgrade by running
                             tunnel traffic through an HTTPS proxy (HOST:PORT)
       --noua                disable user agent
       --notweak             disable TCP optimizations and forced TLS 1.2
-      --json                output in JSON format; implies --exact and --noprompt
+      --json                output in JSON format; implies --noprompt
       --show-browser-logs   do not suppress browser output (stdout and stderr)
       --np, --noprompt      search and exit, do not prompt
       -u, --upgrade         perform in-place self-upgrade

--- a/googler
+++ b/googler
@@ -2299,7 +2299,7 @@ def parse_args(args=None, namespace=None):
     addarg('--notweak', action='store_true',
            help='disable TCP optimizations and forced TLS 1.2')
     addarg('--json', action='store_true',
-           help='output in JSON format; implies --exact and --noprompt')
+           help='output in JSON format; implies --noprompt')
     addarg('--show-browser-logs', action='store_true',
            help='do not suppress browser output (stdout and stderr)')
     addarg('--np', '--noprompt', dest='noninteractive', action='store_true',
@@ -2321,10 +2321,6 @@ def main():
 
     try:
         opts = parse_args()
-
-        # --json implies --exact
-        if opts.json:
-            opts.exact = True
 
         # Set logging level
         if opts.debug:

--- a/googler.1
+++ b/googler.1
@@ -70,7 +70,7 @@ Disable user agent. Results are fetched faster.
 Disable TCP optimizations. Negotiate Transport Layer Security protocol instead of forcing TLS 1.2 (on Python 3.4 and above). Should be used only in case of connection issues.
 .TP
 .BI "--json"
-Output in JSON format; implies \fB--exact\fR and \fB--noprompt\fR.
+Output in JSON format; implies \fB--noprompt\fR.
 .TP
 .BI "--show-browser-logs"
 Do not suppress browser output when opening result in browser; that is, connect stdout and stderr of the browser to googler's stdout and stderr instead of /dev/null. By default, browser output is suppressed (due to certain graphical browsers spewing messages to console) unless the \fBBROWSER\fR environment variable is a known text-based browser: elinks, links, lynx or w3m.


### PR DESCRIPTION
This reverts commit bfcd5e153a15eb63c761426a0f2fc7efd9d71376.

Rationale in #184.