### PR TITLE
.travis.yml: add py36 target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 script:
   - ./tests/ci-test-wrapper --watch .travis.yml


### PR DESCRIPTION
Just realized we haven't added the py36 target (IIRC there were some problems in the beta/rc stage).