### PR TITLE
fix prompt color issues - parse colors with print() before using input()

### DIFF
--- a/googler
+++ b/googler
@@ -1886,7 +1886,8 @@ class GooglerCmd(object):
         enter_count = 0
         while True:
             try:
-                cmd = input(prompt)
+                sys.stderr.write(prompt)
+                cmd = input()
             except EOFError:
                 sys.exit(0)
 


### PR DESCRIPTION
works for me. perhaps there's a more elegant way to do this...