### PR TITLE
Remove reference to Wikipedia article

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,7 @@ optional arguments:
   -n N, --count N       show N results (default 10)
   -N, --news            show results from news section
   -c TLD, --tld TLD     country-specific search with top-level domain .TLD,
-                        e.g., 'in' for India. Ref:
-                        https://en.wikipedia.org/wiki/List_of_Google_domains
+                        e.g., 'in' for India.
   -l LANG, --lang LANG  display in language LANG
   -x, --exact           disable automatic spelling correction
   -C, --nocolor         disable color output

--- a/googler
+++ b/googler
@@ -2398,7 +2398,7 @@ def parse_args(args=None, namespace=None):
            help='show results from news section')
     addarg('-c', '--tld', metavar='TLD',
            help="""country-specific search with top-level domain .TLD, e.g., 'in'
-           for India. Ref: https://en.wikipedia.org/wiki/List_of_Google_domains""")
+           for India.""")
     addarg('-l', '--lang', metavar='LANG', help='display in language LANG')
     addarg('-x', '--exact', action='store_true',
            help='disable automatic spelling correction')

--- a/googler.1
+++ b/googler.1
@@ -38,7 +38,7 @@ Show \fIN\fR results (default 10).
 Show results from news section.
 .TP
 .BI "-c, --tld=" TLD
-Country-specific search with top-level domain \fI.TLD\fR, e.g., \fBin\fR for India (refer \fIhttps://en.wikipedia.org/wiki/List_of_Google_domains\fR for a full list of TLDs).
+Country-specific search with top-level domain \fI.TLD\fR, e.g., \fBin\fR for India.
 .TP
 .BI "-l, --lang=" LANG
 Search for the language \fILANG\fR, e.g., \fBfi\fR for Finnish.


### PR DESCRIPTION
The Wikipedia article linked in documentation was deleted in July 2017.
As such, linking to it is no longer helpful. This commit removes
references to it.