### PR TITLE
If proxy environment variable has '/' after port number, googler fails.

### DIFF
--- a/googler
+++ b/googler
@@ -2360,7 +2360,7 @@ def parse_proxy_spec(proxyspec):
         pos = proxyspec.find('@')
         user_passwd = urllib.parse.unquote(proxyspec[:pos])
         # Remove trailing '/' if any
-        host_port = proxyspec[pos+1:].replace( r'/', '' ) 
+        host_port = proxyspec[pos+1:].rstrip('/') 
     else:
         user_passwd = None
         host_port = proxyspec

--- a/googler
+++ b/googler
@@ -2340,7 +2340,9 @@ def python_version():
 
 
 def https_proxy_from_environment():
-    return os.getenv('https_proxy')
+    import re
+    # remove leading / from port number if any.
+    return re.sub( r'(\:\d+)\/', r'\1', os.getenv( 'https_proxy') )
 
 
 def parse_proxy_spec(proxyspec):

--- a/googler
+++ b/googler
@@ -2340,9 +2340,7 @@ def python_version():
 
 
 def https_proxy_from_environment():
-    import re
-    # remove leading / from port number if any.
-    return re.sub( r'(\:\d+)\/', r'\1', os.getenv( 'https_proxy') )
+    return os.getenv( 'https_proxy' )
 
 
 def parse_proxy_spec(proxyspec):
@@ -2361,7 +2359,8 @@ def parse_proxy_spec(proxyspec):
     if '@' in proxyspec:
         pos = proxyspec.find('@')
         user_passwd = urllib.parse.unquote(proxyspec[:pos])
-        host_port = proxyspec[pos+1:]
+        # Remove trailing '/' if any
+        host_port = proxyspec[pos+1:].replace( r'/', '' ) 
     else:
         user_passwd = None
         host_port = proxyspec


### PR DESCRIPTION
For proxy environemtn variable such as https_proyx=http://proxy.abc.in:3128/ with leading '/' after port number
, currently googler would not work because '3128/' is not a numeric port. This PR fixes this. This format with '/' works with almost many other tools such as wget, curl etc. '/' after port number is suggested at many places including arch https://wiki.archlinux.org/index.php/proxy_settings .

- ~~~Applicable only for environment variable.~~~
- ~~~If user is passing `--proxy=http://proxy.abc.in:3128/' from command line, it is not applicable.~~~