### PR TITLE
Decode autocompletions using the charset from the Content-Type header (fix #227)

### DIFF
--- a/googler
+++ b/googler
@@ -2391,7 +2391,9 @@ def completer_fetch_completions(prefix):
                urllib.parse.quote(prefix, safe=''))
     # A timeout of 3 seconds seems to be overly generous already.
     resp = urllib.request.urlopen(api_url, timeout=3)
-    respobj = json.loads(resp.read().decode('utf-8'))
+    charset = resp.headers.get_content_charset()
+    logger.debug('Completions charset: %s', charset)
+    respobj = json.loads(resp.read().decode(charset))
 
     # The response object, once parsed as JSON, should look like
     #


### PR DESCRIPTION
Working on #227, we discovered that google doesn't always return autocompletions in UTF-8. Most likely they're always encoded in ISO-8859-1. But to be on the safe side, we'll use the charset from the `Content-Type` to decode the response.