### PR TITLE
Add tags to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 dist/
 *.bak
+tags


### PR DESCRIPTION
In case you don't use it, many people use ctags to jump to definitions of classes/functions etc. Thought I'd add this while I was at it :)