### PR TITLE
Make googler installable with pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 dist/
 *.bak
+googler.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import re
+import shutil
+
+import setuptools
+
+shutil.copyfile('googler', 'googler.py')
+
+with open('googler.py', encoding='utf-8') as fp:
+    version = re.search(r'_VERSION_ = \'(.*?)\'', fp.read()).group(1)
+
+setuptools.setup(
+    name='googler',
+    version=version,
+    url='https://github.com/jarun/googler',
+    license='GPLv3',
+    author='Arun Prakash Jana',
+    author_email='engineerarun@gmail.com',
+    description='Google from the terminal',
+    long_description='See https://github.com/jarun/googler#readme.',
+    py_modules=['googler'],
+    entry_points={
+        'console_scripts': [
+            'googler = googler:main',
+        ],
+    },
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'Intended Audience :: End Users/Desktop',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3 :: Only',
+        'Topic :: Internet :: WWW/HTTP :: Indexing/Search',
+        'Topic :: Utilities',
+    ],
+)


### PR DESCRIPTION
This PR makes googler installable with pip. TLDR: I decided to discard this work in the end. Keeping a copy around just in case.

Rationale: Recently I was porting a few of my Python apps to Windows, and I managed to figure out the pain points of (pure) Python packaging on Windows. To name a few:

1. You can't add a shebang and the x bit to a text file and magically make it executable. A big fuck you to scripting (and especially, calling scripts from scripts).

2. The above can be alleviated by https://docs.python.org/3/faq/windows.html#how-do-i-make-python-scripts-executable, but it does NOT solve all problems. For one, `.py` in `PATHEXT` can't be guaranteed (but the CPython installer does add `.PY` to `PATHEXT`[1], so that's probably a mostly safe assumption). And even then, the script can only be called by name from a console; `os.system`, the `execl/execv` family, `subprocess`, etc. certainly doesn't work.

3. No standard installation location (not that I know of anyway). On *nix we have FHS, we have `/usr/local/bin`. On Windows what do you have? Program Files? Do you just create a `C:\bin`? Unclear.

4. Open files cannot be renamed (unless certain flags can set, it seems) or removed. Forget in-place upgrade, even pip can't upgrade itself. In practice, hunting for the process that's hanging on to a file is a regular occurrence. It's like hunting for the process that blocks unmounting, but for every single file. Good grief.

5. Encoding. Oh my god. 30 years of Windows later, Microsoft still hasn't got the memo on globalization.

My initial idea to package googler for Windows is to use setuptools, wheel and pip. (Btw, eggs have serious problems on Windows, as I recently discovered [2]; wheel is the only way to go.) Letting pip provide a console script is the only way I can think of to provide a .exe on Windows that resolves (1) and (2). However, this approach is a bit complicated, and I couldn't find out how to gracefully handle a major Python upgrade (I'm talking about a minor version of Python here), as the console script and site-package is tied to a particular Python 3.x.

Eventually I decided that the console script approach is not worth it; I doubt Windows users are calling googler from scripts, so a `googler.py` is probably good enough.

[1] https://github.com/python/cpython/blob/e42b705188271da108de42b55d9344642170aa2b/Tools/msi/path/path.wxs#L33
[2] https://github.com/pypa/setuptools/issues/1573