### PR TITLE
Do not let signal handler registration issue stop us

### DIFF
--- a/googler
+++ b/googler
@@ -66,7 +66,11 @@ def sigint_handler(signum, frame):
     print('\nInterrupted.', file=sys.stderr)
     sys.exit(1)
 
-signal.signal(signal.SIGINT, sigint_handler)
+try:
+    signal.signal(signal.SIGINT, sigint_handler)
+except ValueError:
+    # signal only works in main thread
+    pass
 
 
 # Constants


### PR DESCRIPTION
Signal only works in main thread.[1]

This is the only change I need to make in order to run googler in a StaSh shell in Pythonista on iOS. (Pythonista can run googler without this change natively, but the Pythonista console doesn't recognize ANSI escape sequences.)

[1] https://github.com/python/cpython/blob/27e2d1f21975dfb8c0ddcb192fa0f45a51b7977e/Modules/signalmodule.c#L436-L438