### PR TITLE
Rewrite URL copying with screen buffer

### DIFF
--- a/googler
+++ b/googler
@@ -2744,9 +2744,9 @@ class GooglerCmd(object):
                                 copier_params = ['tmux', 'set-buffer']
                                 copier_mode = 'cmdline_arg'
                             elif os.getenv('STY'):  # check for GNU screen
-                                # Try to use GNU screen's exchange-file as fallback.
-                                copier_params = ['screen', '-X', 'readbuf']
-                                copier_mode = 'ext_file'
+                                # Try to use GNU screen's paste buffer as fallback.
+                                copier_params = ['screen', '-X', 'readbuf', '-e', 'utf8']
+                                copier_mode = 'screen_specific'
 
                         if not copier_params:
                             printerr('failed to locate suitable clipboard utility')
@@ -2758,11 +2758,19 @@ class GooglerCmd(object):
                             elif copier_mode == 'cmdline_arg':
                                 Popen(copier_params + [content], stdin=DEVNULL,
                                       stdout=DEVNULL, stderr=DEVNULL).communicate()
+                            elif copier_mode == 'screen_specific':
+                                import tempfile
+                                tmpfd, tmppath = tempfile.mkstemp()
+                                try:
+                                    with os.fdopen(tmpfd, 'wb') as fp:
+                                        fp.write(content)
+                                    copier_params.append(tmppath)
+                                    Popen(copier_params, stdin=DEVNULL,
+                                          stdout=DEVNULL, stderr=DEVNULL).communicate()
+                                finally:
+                                    os.unlink(tmppath)
                             else:
-                                with open('/tmp/screen-exchange', 'wb') as f:
-                                    f.write(content)
-                                Popen(copier_params, stdin=DEVNULL,
-                                      stdout=DEVNULL, stderr=DEVNULL).communicate()
+                                raise ValueError('unknown copier mode %s' % repr(copier_mode))
                     except Exception:
                         raise NoKeywordsException
                 else:


### PR DESCRIPTION
I was reminded tonight, by chance, of this feature, which I intended to rewrite when I first saw it, but then forgot.

---

A couple of issues:

- Avoid race condition with a proper mkstemp'ed file. The primary purpose of
  this commit.

- The copier mode shouldn't be called `ext_file` because it sounds like a
  generic writing to then reading from an external file (btw, what's an
  internal file?), when it's really just GNU Screen-specific. So call it what
  it is.

- Enumerate all possible values of copier_mode, then leave one final
  theoretically unreachable else clause. Makes the final case easier to
  understand without reading a lot of prior code. Like switch/case/default. (I
  actually would like a switch in Python, but PEP 3103 was rejected due to "A
  quick poll during my keynote presentation at PyCon 2007 shows this proposal
  has no popular support. I therefore reject it." I digress.)