### PR TITLE
Enable result metadata extraction in Search mode

### DIFF
--- a/googler
+++ b/googler
@@ -2112,10 +2112,10 @@ class GoogleParser(object):
                     title = mime.text + ' ' + title
                 url = self.unwrap_link(a.attr('href'))
                 abstract = div_g.select('.st').text.replace('\n', '')
-                if self.news:
+                try:
                     metadata = div_g.select('.slp').text
-                    metadata = metadata.replace('\u200e', '').replace(' - ', ', ')
-                else:
+                    metadata = metadata.replace('\u200e', '').replace(' - ', ', ').strip()
+                except AttributeError:
                     metadata = None
             except (AttributeError, ValueError):
                 continue


### PR DESCRIPTION
Result metadata (contained in a div.slp in search results) was originally
designed to be extracted in News mode, for publisher name and time of
publishing. (In Search mode, the most important metadata -- date of the page,
when available -- is already contained in the abstract itself. Maybe this info
could be promoted to the separate metadata field, but that's the topic for
another day.)

However, the old parser did not explicitly restrict the extraction to News
mode, which unintentionally let through useful information, e.g., IMDb rating
when searching for a movie. The new parser (ad965d6) instead restricted
metadata extraction to News mode, causing a regression in certain cases.

This commit removes the limitation and allows metadata extraction whenever
possible.