### PR TITLE
CircleCI integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,78 @@
+version: 2
+
+test-template: &test-template
+  working_directory: ~/googler
+  environment:
+    CI_FORCE_TEST: 1
+  steps:
+    - run: apt update && apt install -y --no-install-recommends git wamerican
+    - checkout
+    - run: ./tests/ci-test-wrapper
+
+jobs:
+  py34:
+    docker:
+      - image: python:3.4-slim
+    <<: *test-template
+
+  py35:
+    docker:
+      - image: python:3.5-slim
+    <<: *test-template
+
+  py36:
+    docker:
+      - image: python:3.6-slim
+    <<: *test-template
+
+  py37:
+    docker:
+      - image: python:3.7-slim
+    <<: *test-template
+
+  package-and-publish:
+    machine: true
+    working_directory: ~/googler
+    steps:
+      - checkout
+      - run:
+          name: "package with packagecore"
+          command: |
+            # Use latest installed python3 from pyenv
+            export PYENV_VERSION="$(pyenv versions | grep -Po '\b3\.\d+\.\d+' | tail -1)"
+            pip install packagecore
+            packagecore -o ./dist/ ${CIRCLE_TAG#v}
+      - run:
+          name: "publish to GitHub"
+          command: |
+            go get github.com/tcnksm/ghr
+            ghr -t ${GITHUB_API_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${CIRCLE_TAG} ./dist/
+
+workflows:
+  version: 2
+
+  test:
+    jobs: &all-tests
+      - py34
+      - py35
+      - py36
+      - py37
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs: *all-tests
+
+  publish-github-release:
+    jobs:
+      - package-and-publish:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <p align="center">
 <a href="https://repology.org/metapackage/googler"><img src="https://repology.org/badge/tiny-repos/googler.svg" alt="Availability"></a>
 <a href="https://github.com/jarun/googler/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-yellow.svg?maxAge=2592000" alt="License" /></a>
-<a href="https://travis-ci.org/jarun/googler"><img src="https://travis-ci.org/jarun/googler.svg?branch=master" alt="Build Status" /></a>
+<a href="https://circleci.com/gh/jarun/workflows/googler"><img src="https://img.shields.io/circleci/project/github/jarun/googler.svg" alt="Build Status" /></a>
 </p>
 
 <p align="center">

--- a/packagecore.yaml
+++ b/packagecore.yaml
@@ -85,16 +85,6 @@ packages:
       - make
     deps:
       - python3
-  opensuse42.1:
-    builddeps:
-      - make
-    deps:
-      - python3
-  opensuse42.2:
-    builddeps:
-      - make
-    deps:
-      - python3
   opensuse42.3:
     builddeps:
       - make

--- a/packagecore.yaml
+++ b/packagecore.yaml
@@ -7,12 +7,6 @@ commands:
   install:
     - make PREFIX="/usr" install DESTDIR="${BP_DESTDIR}"
 packages:
-  archlinux:
-    builddeps:
-      - make
-    deps:
-      - python
-    container: "archlinux/base"
   centos7.0:
     builddeps:
       - make

--- a/tests/ci-test-wrapper
+++ b/tests/ci-test-wrapper
@@ -3,7 +3,7 @@
 set -e
 
 declare here repo_root test_script
-here="$(perl -e 'use File::Basename; use Cwd "abs_path"; print dirname(abs_path(@ARGV[0]));' -- "$0")"
+here="$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[2]).parent.resolve())' -- "$0")"
 repo_root="$here/.."
 test_script="$here/test"
 export GIT_DIR="$here/../.git"


### PR DESCRIPTION
Sample workflows on zmwangx/googler:

- `test`: https://circleci.com/workflow-run/1f4a8526-400f-445e-b422-e597b9ff7b6d
- `publish-github-release`: https://circleci.com/workflow-run/797459e2-7acb-453b-8970-bb3f412c74b1 (published artifacts can be seen here: https://github.com/zmwangx/googler/releases/tag/v3.8-cicleci)
- I also configured a `nightly` workflow that's run every day at 00:00 UTC. No run just yet, but by now I've configured nightly workflows on several of my projects so it definitely should be working.

I dropped the following targets from `packagecore.yml`: `archlinux`, `opensuse42.1`, `opensuse42.2`. Rationale is documented in the relevant commit messages.

To test jarun/googler you need to set it up at https://circleci.com/add-projects/gh/jarun first (collaborators don't have permissions). **The following env vars should be configured at https://circleci.com/gh/jarun/googler/edit#env-vars before any job is run:**

- `NUM_TEST_ITERATIONS=10` (inherited from Travis);
- `SLEEP_DURATION=8` (inherited from Travis);
- `GITHUB_API_TOKEN=...` a personal access token with `public_repo` scope to upload release artifacts.

Once this is happily running for a while, we can disable Travis (otherwise we get duplicate artifact uploads that overwrite each other).

Closes #273.