### PR TITLE
Fix metadata extraction of YouTube results

### DIFF
--- a/googler
+++ b/googler
@@ -2202,11 +2202,14 @@ class GoogleParser(object):
                 matched_keywords = []
                 abstract = ''
                 for childnode in div_g.select('.st').children:
+                    if 'f' in childnode.classes:
+                        # .f is handled as metadata instead.
+                        continue
                     if childnode.tag == 'b' and childnode.text != '...':
                         matched_keywords.append({'phrase': childnode.text, 'offset': len(abstract)})
                     abstract = abstract + childnode.text.replace('\n', '')
                 try:
-                    metadata = div_g.select('.slp').text
+                    metadata = div_g.select('.f').text
                     metadata = metadata.replace('\u200e', '').replace(' - ', ', ').strip()
                 except AttributeError:
                     metadata = None


### PR DESCRIPTION
Recently noticed that metadata in YouTube results isn't parsed correctly. To add insult to injury, the semantically important `<br>` tag is dropped amongst other semantically unimportant ones, causing metadata and abstract to be joined without a space in between.

Before:

    $ googler --np gangnam style

     1.  PSY- Gangnam Style (Official Music Video) - YouTube
         https://www.youtube.com/watch?v=CH1XGdu-hzQ
         23 Oct 2012 - 5 min - Uploaded by DanceGangnamStyle50+ videos Play all Mix - PSY- Gangnam Style (Official Music Video)YouTube ·  Darci Lynne ...

After:

    $ googler --np gangnam style

     1.  PSY- Gangnam Style (Official Music Video) - YouTube
         https://www.youtube.com/watch?v=CH1XGdu-hzQ
         23 Oct 2012, 5 min, Uploaded by DanceGangnamStyle
         50+ videos Play all Mix - PSY- Gangnam Style (Official Music Video)YouTube ·  Darci Lynne ...

This is a slightly risky change since metadata criterion changed from `.slp` to `.f` (metadata in the traditional setting is always `.f.slp` in my experience). Not sure if there's regional variance.