### PR TITLE
Drop option --nohl

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,6 @@ optional arguments:
                         --colorize=always
   -C, --nocolor         equivalent to --colorize=never
   --colors COLORS       set output colors (see man page for details)
-  --nohl                do not highlight keyword matches in abstract
   -j, --first, --lucky  open the first result in web browser and exit
   -t dN, --time dN      time limit search [h5 (5 hrs), d5 (5 days), w5 (5
                         weeks), m5 (5 months), y5 (5 years)]

--- a/auto-completion/bash/googler-completion.bash
+++ b/auto-completion/bash/googler-completion.bash
@@ -21,7 +21,6 @@ _googler () {
         --colorize
         -C --nocolor
         --colors
-        --nohl
         -j --first --lucky
         -t --time
         -w --site

--- a/auto-completion/fish/googler.fish
+++ b/auto-completion/fish/googler.fish
@@ -23,7 +23,6 @@ complete -c googler -s x -l exact             --description 'disable automatic s
 complete -c googler -l colorize    -r         --description 'whether to colorize output (options: auto/always/never)'
 complete -c googler -s C -l nocolor           --description 'disable color output'
 complete -c googler -l colors      -r         --description 'set output colors'
-complete -c googler -l nohl                   --description 'do not highlight keyword matches'
 complete -c googler -s j -l first -l lucky    --description 'open the first result in a web browser'
 complete -c googler -s t -l time   -r         --description 'time limit search (h/d/w/m/y + number)'
 complete -c googler -s w -l site   -r         --description 'search a site using Google'

--- a/auto-completion/zsh/_googler
+++ b/auto-completion/zsh/_googler
@@ -44,7 +44,6 @@ args=(
     '(--colorize)--colorize[whether to colorize output]:auto/always/never'
     '(-C --nocolor)'{-C,--nocolor}'[disable color output]'
     '(--colors)--colors[set output colors]:six-letter string'
-    '(--nohl)--nohl[do not highlight keyword matches]'
     '(-j --first --lucky)'{-j,--first,--lucky}'[open the first result in a web browser]'
     '(-t --time)'{-t,--time}'[time limit search]:period (h/d/w/m/y + number)'
     '(-w --site)'{-w,--site}'[search a site using Google]:domain'

--- a/googler
+++ b/googler
@@ -2312,7 +2312,6 @@ class Result(object):
     Class Variables
     ---------------
     colors : str
-    nohl : bool
 
     Methods
     -------
@@ -2324,7 +2323,6 @@ class Result(object):
 
     # Class variables
     colors = None
-    nohl = False
     urlexpand = True
 
     def __init__(self, index, title, url, abstract, metadata=None, sitelinks=None, matches=None):
@@ -2381,7 +2379,7 @@ class Result(object):
 
         fillwidth = (columns - (indent + 6)) if columns > indent + 6 else len(abstract)
         wrapped_abstract = TrackedTextwrap(abstract, fillwidth)
-        if colors and not self.nohl:
+        if colors:
             # Highlight matches.
             for match in matches or []:
                 offset = match['offset']
@@ -3277,7 +3275,6 @@ def parse_args(args=None, namespace=None):
     addarg('--colors', dest='colorstr', type=argparser.is_colorstr,
            default=colorstr_env if colorstr_env else 'GKlgxy', metavar='COLORS',
            help='set output colors (see man page for details)')
-    addarg('--nohl', action='store_true', help='do not highlight keyword matches in abstract')
     addarg('-j', '--first', '--lucky', dest='lucky', action='store_true',
            help='open the first result in web browser and exit')
     addarg('-t', '--time', dest='duration', type=argparser.is_duration,
@@ -3364,7 +3361,6 @@ def main():
         else:
             colors = None
         Result.colors = colors
-        Result.nohl = opts.nohl
         Result.urlexpand = True if os.getenv('DISABLE_URL_EXPANSION') is None else False
         GooglerCmd.colors = colors
 


### PR DESCRIPTION
This reverts commit 7e725573f801c587df7688a07f9fc7a9408d76eb.

Per discussion[1], the value proposition has changed now that text wrapping in
presence of ANSI escape sequences has been fixed.

[1] https://github.com/jarun/googler/pull/300#issuecomment-554608255