### PR TITLE
Fix .replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
 language = "python3"
-run = "./googler"
+run = "python ./googler"


### PR DESCRIPTION
Repl.it struggles with persisting file permissions so this changes the run command to run it as a python script instead of an executable. cc @Mosrod 
<img width="1314" alt="Screen Shot 2019-12-09 at 10 07 35 PM" src="https://user-images.githubusercontent.com/587518/70500456-77951480-1ad0-11ea-81f2-81a910ddd106.png">
