### PR TITLE
Introduce options --from and --to for date range

### DIFF
--- a/auto-completion/bash/googler-completion.bash
+++ b/auto-completion/bash/googler-completion.bash
@@ -24,6 +24,8 @@ _googler () {
         --colors
         -j --first --lucky
         -t --time
+        --from
+        --to
         -w --site
         --unfilter
         -p --proxy
@@ -45,6 +47,8 @@ _googler () {
         --colorize
         --colors
         -t --time
+        --from
+        --to
         -w --site
         -p --proxy
         --url-handler

--- a/auto-completion/fish/googler.fish
+++ b/auto-completion/fish/googler.fish
@@ -26,6 +26,8 @@ complete -c googler -s C -l nocolor           --description 'disable color outpu
 complete -c googler -l colors      -r         --description 'set output colors'
 complete -c googler -s j -l first -l lucky    --description 'open the first result in a web browser'
 complete -c googler -s t -l time   -r         --description 'time limit search (h/d/w/m/y + number)'
+complete -c googler -l from        -r         --description 'starting date/month/year of date range'
+complete -c googler -l to          -r         --description 'ending date/month/year of date range'
 complete -c googler -s w -l site   -r         --description 'search a site using Google'
 complete -c googler -l unfilter               --description 'do not omit similar results'
 complete -c googler -s p -l proxy  -r         --description 'proxy in HOST:PORT format'

--- a/auto-completion/zsh/_googler
+++ b/auto-completion/zsh/_googler
@@ -47,6 +47,8 @@ args=(
     '(--colors)--colors[set output colors]:six-letter string'
     '(-j --first --lucky)'{-j,--first,--lucky}'[open the first result in a web browser]'
     '(-t --time)'{-t,--time}'[time limit search]:period (h/d/w/m/y + number)'
+    '(--from)--from[starting date/month/year of date range]:date m/d/yyyy'
+    '(--to)--to[ending date/month/year of date range]:date m/d/yyyy'
     '(-w --site)'{-w,--site}'[search a site using Google]:domain'
     '(--unfilter)--unfilter[do not omit similar results]'
     '(-p --proxy)'{-p,--proxy}'[proxy in HOST:PORT format]:proxy details'

--- a/googler
+++ b/googler
@@ -1739,6 +1739,10 @@ class GoogleUrl(object):
                 qd['nfpr'] = 1
             else:
                 qd.pop('nfpr', None)
+        if 'from' in opts or 'to' in opts:
+            cd_min = opts.get('from', '')
+            cd_max = opts.get('to', '')
+            qd['tbs'] = 'cdr:1,cd_min:%s,cd_max:%s' % (cd_min, cd_max)
         if 'keywords' in opts:
             self._keywords = opts['keywords']
         if 'lang' in opts and opts['lang']:
@@ -3009,6 +3013,15 @@ class GooglerArgumentParser(argparse.ArgumentParser):
         return arg
 
     @staticmethod
+    def is_date(arg):
+        """Check if a string is a valid date/month/year accepted by Google."""
+        if re.match(r'^(\d+/){0,2}\d+$', arg):
+            return arg
+        else:
+            raise argparse.ArgumentTypeError('%s is not a valid date/month/year; '
+                                             'use the American date format with slashes')
+
+    @staticmethod
     def is_colorstr(arg):
         """Check if a string is a valid color string."""
         try:
@@ -3308,6 +3321,12 @@ def parse_args(args=None, namespace=None):
     addarg('-t', '--time', dest='duration', type=argparser.is_duration,
            metavar='dN', help='time limit search '
            '[h5 (5 hrs), d5 (5 days), w5 (5 weeks), m5 (5 months), y5 (5 years)]')
+    addarg('--from', type=argparser.is_date,
+           help="""starting date/month/year of date range; must use American date
+           format with slashes, e.g., 2/24/2020, 2/2020, 2020; can be used in
+           conjuction with --to, and overrides -t, --time""")
+    addarg('--to', type=argparser.is_date,
+           help='ending date/month/year of date range; see --from')
     addarg('-w', '--site', dest='sites', action='append', metavar='SITE',
            help='search a site using Google')
     addarg('--unfilter', action='store_true', help='do not omit similar results')


### PR DESCRIPTION
Fixes #320.

- Note1: I'm not 100% sure the dates must match `r'^(\d+/){0,2}\d+$'`.
- Note2: Not gonna introduce more short options, in part because `--to` clashes with `-t`, and the usual convention of making it `-T` somehow doesn't feel right.