### PR TITLE
Add the `--url-output` option for writing selected URLs to a file.

### DIFF
--- a/googler
+++ b/googler
@@ -3350,9 +3350,9 @@ def parse_args(args=None, namespace=None):
            help='disable TCP optimizations and forced TLS 1.2')
     addarg('--json', action='store_true',
            help='output in JSON format; implies --noprompt')
-    addarg('--url-handler', metavar='URL_HANDLER',
+    addarg('--url-handler', metavar='UTIL',
            help='custom script or cli utility to open results')
-    addarg('--url-output', metavar='URL_OUTPUT',
+    addarg('--url-output', metavar='FILE',
            help='file to write urls to')
     addarg('--show-browser-logs', action='store_true',
            help='do not suppress browser output (stdout and stderr)')

--- a/googler
+++ b/googler
@@ -1390,6 +1390,13 @@ def open_url(url):
     in a custom CLI script or utility. A subprocess is spawned with url as
     the parameter in this case instead of the usual webbrowser.open() call.
 
+    The file stream ``open_url.url_output`` can be used to write opened URLs to.
+    The URL and a newline are written to the file, which is then flushed.
+    When the file is a pipe, this makes it easy for a shell to read in the URLs
+    from the named pipe and run commands on them in parallel to googler.
+    It is very difficult (and/or slow) to run bash functions, for example,
+    using ``open_url.url_handler``.  This makes that much simpler.
+
     Whether the browser's output (both stdout and stderr) are suppressed
     depends on the boolean attribute ``open_url.suppress_browser_output``.
     If the attribute is not set upon a call, set it to a default value,
@@ -1408,6 +1415,11 @@ def open_url(url):
     if hasattr(open_url, 'url_handler'):
         p = Popen([open_url.url_handler, url], stdin=PIPE)
         p.communicate()
+        return
+    if hasattr(open_url, 'url_output'):
+        out = open_url.url_output
+        out.write(url + '\n')
+        out.flush()
         return
 
     browser = webbrowser.get()
@@ -3338,8 +3350,10 @@ def parse_args(args=None, namespace=None):
            help='disable TCP optimizations and forced TLS 1.2')
     addarg('--json', action='store_true',
            help='output in JSON format; implies --noprompt')
-    addarg('--url-handler', metavar='UTIL',
+    addarg('--url-handler', metavar='URL_HANDLER',
            help='custom script or cli utility to open results')
+    addarg('--url-output', metavar='URL_OUTPUT',
+           help='file to write urls to')
     addarg('--show-browser-logs', action='store_true',
            help='do not suppress browser output (stdout and stderr)')
     addarg('--np', '--noprompt', dest='noninteractive', action='store_true',
@@ -3417,6 +3431,8 @@ def main():
 
         if opts.url_handler is not None:
             open_url.url_handler = opts.url_handler
+        elif opts.url_output is not None:
+            open_url.url_output = open(opts.url_output, 'w')
         else:
             # Set text browser override to False
             open_url.override_text_browser = False


### PR DESCRIPTION
Instead of running a new process for each selected URL like with `--url-handler`, 
`--url-output` takes a file path, which it writes the selected URLs to, delimited by `\n`.

This can be much more useful and efficient than `--url-handler`.
`--url-handler` requires an executable to run for each URL,
but does not allow any extra arguments to be sent to the program,
and since it must be an executable, it can't be a bash function, for example.

`--url-output`, when the file path is a named pipe, allows for much more robust url handling.
The program that reads from the pipe as googler writes to it can do anything,
including running a bash function or passing extra args to it, 
and it also avoids forking a new process for each URL.