### PR TITLE
Fix news search

### DIFF
--- a/googler
+++ b/googler
@@ -2253,6 +2253,23 @@ class GoogleParser(object):
             self.results.append(Result(index, title, url, abstract,
                                        metadata=metadata, sitelinks=sitelinks, matches=matched_keywords))
 
+        if not self.results:
+            for card in tree.select_all('g-card'):
+                a = card.select('a[href]')
+                if not a:
+                    continue
+                url = self.unwrap_link(a.attr('href'))
+                text_nodes = []
+                for node in a.descendants():
+                    if isinstance(node, TextNode) and node.strip():
+                        text_nodes.append(node.text)
+                if len(text_nodes) != 4:
+                    continue
+                publisher, title, abstract, publishing_time = text_nodes
+                metadata = '%s, %s' % (publisher, publishing_time)
+                index += 1
+                self.results.append(Result(index, title, url, abstract, metadata=metadata))
+
         # Showing results for ...
         # Search instead for ...
         spell_orig = tree.select("span.spell_orig")

--- a/googler
+++ b/googler
@@ -1747,16 +1747,12 @@ class GoogleUrl(object):
             self._keywords = opts['keywords']
         if 'lang' in opts and opts['lang']:
             qd['hl'] = opts['lang']
-        if 'news' in opts:
-            if opts['news']:
-                qd['tbm'] = 'nws'
-            else:
-                qd.pop('tbm', None)
-        if 'videos' in opts:
-            if opts['videos']:
-                qd['tbm'] = 'vid'
-            else:
-                qd.pop('tbm', None)
+        if 'news' in opts and opts['news']:
+            qd['tbm'] = 'nws'
+        elif 'videos' in opts and opts['videos']:
+            qd['tbm'] = 'vid'
+        else:
+            qd.pop('tbm', None)
         if 'num' in opts:
             self._num = opts['num']
         if 'sites' in opts:


### PR DESCRIPTION
Two issues.

1. Regression caused by cacf7ffe5a3044453ae7ee970c9c9c0590362516. Before the fix, `--news` is effectively discarded because `--videos` caused `tbm` to be either overwritten or popped.

2. I'm seeing #316 again, and it's not like I use `googler -N` every day -- I haven't touched it since #316, and I believe I've been mostly or exclusively seeing the new layout in my sparing use of Google News, so I suspect it's not an anomaly. Since I already wrote a completely backward-compatible patch capable of handling both layouts, I figured why not.