### PR TITLE
Strip trailing comma from metadata

### DIFF
--- a/googler
+++ b/googler
@@ -2234,7 +2234,7 @@ class GoogleParser(object):
                     abstract = abstract + childnode.text.replace('\n', '')
                 try:
                     metadata = div_g.select('.f').text
-                    metadata = metadata.replace('\u200e', '').replace(' - ', ', ').strip()
+                    metadata = metadata.replace('\u200e', '').replace(' - ', ', ').strip().rstrip(',')
                 except AttributeError:
                     metadata = None
             except (AttributeError, ValueError):


### PR DESCRIPTION
Without this patch we could see awkward output like

```
  3.  iNEWS FTP/FTPS Server Specification - Avid
       http://resources.avid.com/SupportFiles/attach/Broadcast/iNEWS-FTP-FTPS-ServerProtocol.pdf
       Sep 25, 2017,
       FTP (File Transfer Protocol) interaction. The iNEWS FTP Server supports a subset of the FTP commands described in the FTP specification and ...
```