### PR TITLE
Restore daily tests and packaging on tags

### DIFF
--- a/.github/workflows/build-and-upload-artifacts.yml
+++ b/.github/workflows/build-and-upload-artifacts.yml
@@ -1,0 +1,32 @@
+name: build and upload artifacts
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  build-and-upload-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install PackageCore
+        run: |
+          python -m pip install --upgrade pip
+          pip install packagecore
+      - name: Build artifacts with PackageCore
+        run: |
+          version=${GITHUB_REF##*/v}
+          packagecore -o dist/ "$version"
+      - name: Create draft release with artifacts
+        run: |
+          tag=${GITHUB_REF##*/}
+          asset_options=()
+          for asset in dist/*; do
+            asset_options+=(-a "$asset")
+          done
+          hub release create --draft "${asset_options[@]}" --message "googler $tag" "$tag"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stylecheck.yml
+++ b/.github/workflows/stylecheck.yml
@@ -4,15 +4,15 @@ jobs:
   stylecheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Install dev dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install black
-    - name: Style check with black
-      run: |
-        black --check --quiet --diff tests/*.py
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install black
+      - name: Style check with black
+        run: |
+          black --check --quiet --diff tests/*.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,23 +1,26 @@
 name: test
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
-      fail-fast:
-        false
+      fail-fast: false
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dev dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest
-    - name: Test with pytest
-      run: |
-        pytest
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Test with pytest
+        run: |
+          pytest

--- a/packagecore.yaml
+++ b/packagecore.yaml
@@ -1,0 +1,88 @@
+name: googler
+maintainer: Arun Prakash Jana <engineerarun@gmail.com>
+license: GPLv3
+summary: Google from the command-line.
+homepage: https://github.com/jarun/googler
+commands:
+  install:
+    - make PREFIX="/usr" install DESTDIR="${BP_DESTDIR}"
+packages:
+  archlinux:
+    builddeps:
+      - make
+    deps:
+      - python
+    container: "archlinux/base"
+  centos7.5:
+    builddeps:
+      - make
+    deps:
+      - python
+  centos7.6:
+    builddeps:
+      - make
+    deps:
+      - python
+  centos7.7:
+    builddeps:
+      - make
+    deps:
+      - python
+  centos8.0:
+    builddeps:
+      - make
+    deps:
+      - python3
+    commands:
+      precompile:
+        - dnf install python3
+  debian8:
+    builddeps:
+      - make
+    deps:
+      - python3
+  debian9:
+    builddeps:
+      - make
+    deps:
+      - python3
+  debian10:
+    builddeps:
+      - make
+    deps:
+      - python3
+  fedora30:
+    builddeps:
+      - make
+    deps:
+      - python3
+  fedora31:
+    builddeps:
+      - make
+    deps:
+      - python3
+  opensuse15.1:
+    builddeps:
+      - make
+    deps:
+      - python3
+  ubuntu14.04:
+    builddeps:
+      - make
+    deps:
+      - python3
+  ubuntu16.04:
+    builddeps:
+      - make
+    deps:
+      - python3
+  ubuntu18.04:
+    builddeps:
+      - make
+    deps:
+      - python3
+  ubuntu20.04:
+    builddeps:
+      - make
+    deps:
+      - python3

--- a/tests/test_googler.py
+++ b/tests/test_googler.py
@@ -79,8 +79,8 @@ def test_site_search():
     def be_from_wikipedia(result):
         return result["url"].startswith("https://en.wikipedia.org")
 
-    gr = GR(["site:en.wikipedia.org google"])
-    gr.all_should(be_from_wikipedia)
+    GR(["--site=en.wikipedia.org", "google"]).all_should(be_from_wikipedia)
+    GR(["site:en.wikipedia.org google"]).all_should(be_from_wikipedia)
 
 
 @pytest.mark.parametrize("tld", ["in", "de"])


### PR DESCRIPTION
Packaging is slow (takes ~20min) and I had to iterate a few times due to various stupid mistakes, so I eventually let it run overnight. Here's a successful build https://github.com/zmwangx/googler/runs/707042399?check_suite_focus=true, and here's the automated release created from that: https://github.com/zmwangx/googler/releases/tag/v4.1.packaging_test (The workflow only creates a draft release, so you can still edit it before publishing.)