### PR TITLE
Fix sitelinks parsing

### DIFF
--- a/googler
+++ b/googler
@@ -2298,7 +2298,7 @@ class GoogleParser(object):
                     a = td.select('a')
                     sl_title = a.text
                     sl_url = self.unwrap_link(a.attr('href'))
-                    sl_abstract = td.select('div.s.st').text
+                    sl_abstract = td.select('div.s.st, div.s .st').text
                     sitelinks.append(Sitelink(cw(sl_title), sl_url, cw(sl_abstract)))
                 except (AttributeError, ValueError):
                     continue


### PR DESCRIPTION
Sitelink abstract now bears the following structure

```html
<div class="s">
  <div class="st" style="overflow:hidden;width:220px">Sign in. Use your Google Account ... Use Guest mode to sign in ...<br></div>
</div>
```

at least for me. I think the parser has been broken for quite a while in this regard.