### PR TITLE
Do not print an additional blank line when abstract is empty

### DIFF
--- a/googler
+++ b/googler
@@ -2483,22 +2483,24 @@ class Result(object):
             else:
                 print(' ' * (indent + 5) + metadata)
 
-        fillwidth = (columns - (indent + 6)) if columns > indent + 6 else len(abstract)
-        wrapped_abstract = TrackedTextwrap(abstract, fillwidth)
-        if colors:
-            # Highlight matches.
-            for match in matches or []:
-                offset = match['offset']
-                span = len(match['phrase'])
-                wrapped_abstract.insert_zero_width_sequence('\x1b[1m', offset)
-                wrapped_abstract.insert_zero_width_sequence('\x1b[0m', offset + span)
+        if abstract:
+            fillwidth = (columns - (indent + 6)) if columns > indent + 6 else len(abstract)
+            wrapped_abstract = TrackedTextwrap(abstract, fillwidth)
+            if colors:
+                # Highlight matches.
+                for match in matches or []:
+                    offset = match['offset']
+                    span = len(match['phrase'])
+                    wrapped_abstract.insert_zero_width_sequence('\x1b[1m', offset)
+                    wrapped_abstract.insert_zero_width_sequence('\x1b[0m', offset + span)
 
-        if colors:
-            print(colors.abstract, end='')
-        for line in wrapped_abstract.lines:
-            print('%s%s' % (' ' * (indent + 5), line))
-        if colors:
-            print(colors.reset, end='')
+            if colors:
+                print(colors.abstract, end='')
+            for line in wrapped_abstract.lines:
+                print('%s%s' % (' ' * (indent + 5), line))
+            if colors:
+                print(colors.reset, end='')
+
         print('')
 
     def print(self):


### PR DESCRIPTION
Not actually sure why we never changed this... But I happened to be developing against a request that resulted in an empty abstract today, and the double blank line sure looked pointless (especially when it's repeated due to the result duplication bug).

Before (yeah, this is without the duplicate suppression):

```console
$ ./googler python3.5 eol

 1.  Is there official guide for Python 3.x release lifecycle? - Stack ...
     https://stackoverflow.com/questions/40655195/is-there-official-guide-for-python-3-x-release-lifecycle


 2.  Is there official guide for Python 3.x release lifecycle? - Stack ...
     https://stackoverflow.com/questions/40655195/is-there-official-guide-for-python-3-x-release-lifecycle


 3.  17. Development Cycle — Python Developer's Guide
     https://devguide.python.org/devcycle/
     A branch less than 5 years old but no longer in maintenance mode is a ... For reference, here are the Python versions that most recently reached their
     end-of-life: ...
```

After:

```console
$ ./googler python3.5 eol

 1.  Is there official guide for Python 3.x release lifecycle? - Stack ...
     https://stackoverflow.com/questions/40655195/is-there-official-guide-for-python-3-x-release-lifecycle

 2.  Is there official guide for Python 3.x release lifecycle? - Stack ...
     https://stackoverflow.com/questions/40655195/is-there-official-guide-for-python-3-x-release-lifecycle

 3.  17. Development Cycle — Python Developer's Guide
     https://devguide.python.org/devcycle/
     A branch less than 5 years old but no longer in maintenance mode is a ... For reference, here are the Python versions that most recently reached their
     end-of-life: ...
```

(As an aside, it would be nice if we could actually display the text in a featured snippet, but those snippets are a little bit too liberal in format to reliably parse, so I guess we're stuck with a bare title and URL for now).