### PR TITLE
Replace uuid1 with uuid4 for privacy purpose

### DIFF
--- a/googler
+++ b/googler
@@ -1661,7 +1661,7 @@ class GoogleUrl(object):
             'ie': 'UTF-8',
             'oe': 'UTF-8',
             #'gbv': '1',  # control the presence of javascript on the page, 1=no js, 2=js
-            'sei': base64.encodebytes(uuid.uuid1().bytes).decode("ascii").rstrip('=\n').replace('/', '_'),
+            'sei': base64.encodebytes(uuid.uuid4().bytes).decode("ascii").rstrip('=\n').replace('/', '_'),
         }
 
         # In preloaded HTML parsing mode, set keywords to something so


### PR DESCRIPTION
uuid1 is generated by mixing the host computers MAC address, and the
current time. The uniqueness comes at the cost of anonymity, which means
this may leak the machine's MAC address to Google.

Instead, uuid4 is generated randomly, and it almost impossible to occur the
conflict situation unless generating trillions of IDs every in a short time.

This patch was provided by Jakub Wilk [1].

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=965066

Signed-off-by: Jakub Wilk <jwilk@jwilk.net>
Signed-off-by: SZ Lin (林上智) <szlin@debian.org>