### PR TITLE
This fixes issue https://github.com/jarun/googler/issues/347 without using cookies.

### DIFF
--- a/googler
+++ b/googler
@@ -1794,6 +1794,8 @@ class GoogleUrl(object):
             self._keywords = opts['keywords']
         if 'lang' in opts and opts['lang']:
             qd['hl'] = opts['lang']
+        if 'geoloc' in opts and opts['geoloc']:
+            qd['gl'] = opts['geoloc']
         if 'news' in opts and opts['news']:
             qd['tbm'] = 'nws'
         elif 'videos' in opts and opts['videos']:
@@ -3480,6 +3482,9 @@ def parse_args(args=None, namespace=None):
            help="""country-specific search with top-level domain .TLD, e.g., 'in'
            for India""")
     addarg('-l', '--lang', metavar='LANG', help='display in language LANG')
+    addarg('-g', '--geoloc', metavar='CC', 
+           help="""country-specific geolocation search with country code CC, e.g.
+           'in' for India. Country codes are the same as top-level domains""")
     addarg('-x', '--exact', action='store_true',
            help='disable automatic spelling correction')
     addarg('--colorize', nargs='?', choices=['auto', 'always', 'never'],


### PR DESCRIPTION
Added the option to specifiy the geolocation used by google. This is simply
done by providing the "gl" parameter in the URL. The country codes are the
as the codes used in TLDs.

This might seem unimportant to people in english-speaking countries, but
searching computer related stuff is really annoying when it mixes results
from other languages.