### PR TITLE
Introduce a protocol for Google-breaks-everything incidents

### DIFF
--- a/googler
+++ b/googler
@@ -90,6 +90,7 @@ except ValueError:
 # Constants
 
 _VERSION_ = '4.2'
+_EPOCH_ = '20201001'
 
 COLORMAP = {k: '\x1b[%sm' % v for k, v in {
     'a': '30', 'b': '31', 'c': '32', 'd': '33',
@@ -2773,10 +2774,46 @@ class GooglerCmd(object):
 
     def warn_no_results(self):
         printerr('No results.')
-        if not self.no_results_instructions_shown:
-            printerr('If you believe this is a bug, please review '
-                     'https://git.io/googler-no-results before submitting a bug report.')
-            self.no_results_instructions_shown = True
+        if self.no_results_instructions_shown:
+            return
+
+        try:
+            import json
+            import urllib.error
+            import urllib.request
+            info_json_url = '%s/master/info.json' % RAW_DOWNLOAD_REPO_BASE
+            logger.debug('Fetching %s for project status...', info_json_url)
+            try:
+                with urllib.request.urlopen(info_json_url, timeout=5) as response:
+                    try:
+                        info = json.load(response)
+                    except Exception:
+                        logger.error('Failed to decode project status from %s', info_json_url)
+                        raise RuntimeError
+            except urllib.error.HTTPError as e:
+                logger.error('Failed to fetch project status from %s: HTTP %d', info_json_url, e.code)
+                raise RuntimeError
+            epoch = info.get('epoch')
+            if epoch > _EPOCH_:
+                printerr('Your version of googler is broken due to Google-side changes.')
+                tracking_issue = info.get('tracking_issue')
+                fixed_on_master = info.get('fixed_on_master')
+                fixed_in_release = info.get('fixed_in_release')
+                if fixed_in_release:
+                    printerr('A new version, %s, has been released to address the changes.' % fixed_in_release)
+                    printerr('Please upgrade to the latest version.')
+                elif fixed_on_master:
+                    printerr('The fix has been pushed to master, pending a release.')
+                    printerr('Please download the master version https://git.io/googler or wait for a release.')
+                else:
+                    printerr('The issue is tracked at https://github.com/jarun/googler/issues/%s.' % tracking_issue)
+                return
+        except RuntimeError:
+            pass
+
+        printerr('If you believe this is a bug, please review '
+                 'https://git.io/googler-no-results before submitting a bug report.')
+        self.no_results_instructions_shown = True
 
     @require_keywords
     def display_results(self, prelude='\n', json_output=False):

--- a/info.json
+++ b/info.json
@@ -1,0 +1,6 @@
+{
+    "epoch": "20201001",
+    "tracking_issue": 372,
+    "fixed_on_master": true,
+    "fixed_in_release": false
+}


### PR DESCRIPTION
There have been enough Google-breaks-everything shitstorms, it's time to introduce a better protocol to reduce user confusion during these trying periods.

Here's the protocol:

- Once a report is confirmed and proven to be non-transient (e.g. still reproducible after 24 hours), regardlessly of whether a fix can be made available immediately, the epoch in `googler` and `info.json` should be advanced to the date of the report (in UTC), and the issue number recorded. `info.json` should look like:

  ```json
  {
      "epoch": "20201001",
      "tracking_issue": 372,
      "fixed_on_master": false,
      "fixed_in_release": false
  }
  ```

  At this point users would see a message like this:

  ```console
  $ googler hello  # Issue acknowledged, not fixed.
  No results.
  Your version of googler is broken due to Google-side changes.
  The issue is tracked at https://github.com/jarun/googler/issues/372.
  ```

- Once a fix is committed to master, `fixed_on_master` should be set to `true`:

  ```json
  {
      "epoch": "20201001",
      "tracking_issue": 372,
      "fixed_on_master": true,
      "fixed_in_release": false
  }
  ```

  At this point users would see a message like this:

  ```console
  $ googler hello  # Fixed on master, not released.
  No results.
  Your version of googler is broken due to Google-side changes.
  The fix has been pushed to master, pending a release.
  Please download the master version https://git.io/googler or wait for a release.
  ```

- Once the fix is released, `fixed_in_released` should be updated to the version tag:

  ```json
  {
      "epoch": "20201001",
      "tracking_issue": 372,
      "fixed_on_master": true,
      "fixed_in_release": "v4.3"
  }
  ```

  At this point users would see a message like this:

  ```console
  $ googler hello  # Fix released.
  No results.
  Your version of googler is broken due to Google-side changes.
  A new version, v4.3, has been released to address the changes.
  Please upgrade to the latest version.
  ```

I'll create a wiki page for this protocol if we can agree on it.