### PR TITLE
Add time_it decorator to profile the most time-consuming methods in debug mode

### DIFF
--- a/googler
+++ b/googler
@@ -1556,6 +1556,26 @@ def check_stdout_encoding():
         sys.exit(1)
 
 
+def time_it(description=None):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            # Only profile in debug mode.
+            if not logger.isEnabledFor(logging.DEBUG):
+                return func(*args, **kwargs)
+
+            import time
+            mark = time.perf_counter()
+            ret = func(*args, **kwargs)
+            duration = time.perf_counter() - mark
+            logger.debug('%s completed in \x1b[33m%.3fs\x1b[0m', description or func.__name__, duration)
+            return ret
+
+        return wrapped
+
+    return decorator
+
+
 # Classes
 
 class HardenedHTTPSConnection(HTTPSConnection):
@@ -2084,6 +2104,7 @@ class GoogleConnection(object):
         """The host currently connected to."""
         return self._host
 
+    @time_it()
     def new_connection(self, host=None, port=None, timeout=45):
         """Close the current connection (if any) and establish a new one.
 
@@ -2148,6 +2169,7 @@ class GoogleConnection(object):
         """
         self.new_connection(timeout=timeout)
 
+    @time_it()
     def fetch_page(self, url):
         """Fetch a URL.
 
@@ -2303,6 +2325,7 @@ class GoogleParser(object):
         self.results = []
         self.parse(html)
 
+    @time_it()
     def parse(self, html):
         tree = parse_html(html)
 

--- a/tests/test_googler.py
+++ b/tests/test_googler.py
@@ -19,7 +19,7 @@ class GooglerResults:
     def __init__(self, argv):
         self.argv = argv
         json_output = subprocess.check_output(
-            [str(GOOGLER), *PRESET_OPTIONS, "--json", *argv]
+            [str(GOOGLER), *PRESET_OPTIONS, "--debug", "--json", *argv]
         ).decode("utf-8")
         self.results = json.loads(json_output)
         assert self.results, "no results"


### PR DESCRIPTION
Could be useful for getting a sense of the rough performance of things without pulling out a full blown profiler.

Timing example on a really crappy Linux box:

<img width="491" alt="Screen Shot 2020-10-10 at 10 06 00 PM" src="https://user-images.githubusercontent.com/4149852/95657174-8e1f5880-0b45-11eb-9147-e01d0dbfd279.png">

Related: #382.

